### PR TITLE
Support for PartialEq and Eq for objects with an id

### DIFF
--- a/screeps-game-api/src/objects/impls/construction_site.rs
+++ b/screeps-game-api/src/objects/impls/construction_site.rs
@@ -15,7 +15,7 @@ simple_accessors! {
 }
 
 impl ConstructionSite {
-    pub fn owner(&self) -> String {
+    pub fn owner_name(&self) -> String {
         (js! {
             var self = @{self.as_ref()};
             if (self.owner) {

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -24,6 +24,10 @@ impl Creep {
         js_unwrap!(@{self.as_ref()}.carry[RESOURCE_ENERGY])
     }
 
+    pub fn owner_name(&self) -> String {
+        js_unwrap!(@{self.as_ref()}.owner.username)
+    }
+
     pub fn cancel_order(&self, name: &str) -> ReturnCode {
         js_unwrap!(@{self.as_ref()}.cancelOrder(@{name}))
     }
@@ -148,6 +152,7 @@ macro_rules! creep_simple_concrete_action {
 
 simple_accessors! {
     Creep;
+    (id -> id -> String),
     (carry_capacity -> carryCapacity -> i32),
     (fatigue -> fatigue -> i32),
     (hits -> hits -> i32),
@@ -157,6 +162,15 @@ simple_accessors! {
     (spawning -> spawning -> bool),
     (ticks_to_live -> ticksToLive -> i32),
 }
+
+impl PartialEq for Creep {
+    #[inline]
+    fn eq(&self, other: &Creep) -> bool{
+        self.id() == other.id()
+    }
+}
+
+impl Eq for Creep {}
 
 creep_simple_generic_action! {
     (attack(Attackable) -> attack),

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -164,7 +164,6 @@ simple_accessors! {
 }
 
 impl PartialEq for Creep {
-    #[inline]
     fn eq(&self, other: &Creep) -> bool{
         self.id() == other.id()
     }

--- a/screeps-game-api/src/objects/impls/resource.rs
+++ b/screeps-game-api/src/objects/impls/resource.rs
@@ -14,7 +14,6 @@ simple_accessors! {
 }
 
 impl PartialEq for Resource {
-    #[inline]
     fn eq(&self, other: &Resource) -> bool{
         self.id() == other.id()
     }

--- a/screeps-game-api/src/objects/impls/resource.rs
+++ b/screeps-game-api/src/objects/impls/resource.rs
@@ -10,4 +10,14 @@ impl Resource {
 simple_accessors! {
     Resource;
     (amount -> amount -> i32),
+    (id -> id -> String)
 }
+
+impl PartialEq for Resource {
+    #[inline]
+    fn eq(&self, other: &Resource) -> bool{
+        self.id() == other.id()
+    }
+}
+
+impl Eq for Resource {}

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -127,3 +127,12 @@ impl Room {
         js_unwrap!(@{self.as_ref()}.name)
     }
 }
+
+impl PartialEq for Room {
+    #[inline]
+    fn eq(&self, other: &Room) -> bool{
+        self.name() == other.name()
+    }
+}
+
+impl Eq for Room {}

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -129,7 +129,6 @@ impl Room {
 }
 
 impl PartialEq for Room {
-    #[inline]
     fn eq(&self, other: &Room) -> bool{
         self.name() == other.name()
     }

--- a/screeps-game-api/src/objects/impls/source.rs
+++ b/screeps-game-api/src/objects/impls/source.rs
@@ -7,3 +7,12 @@ simple_accessors! {
     (id -> id -> String),
     (ticks_to_regeneration -> ticksToRegeneration -> u32),
 }
+
+impl PartialEq for Source {
+    #[inline]
+    fn eq(&self, other: &Source) -> bool{
+        self.id() == other.id()
+    }
+}
+
+impl Eq for Source {}

--- a/screeps-game-api/src/objects/impls/source.rs
+++ b/screeps-game-api/src/objects/impls/source.rs
@@ -9,7 +9,6 @@ simple_accessors! {
 }
 
 impl PartialEq for Source {
-    #[inline]
     fn eq(&self, other: &Source) -> bool{
         self.id() == other.id()
     }

--- a/screeps-game-api/src/objects/impls/tombstone.rs
+++ b/screeps-game-api/src/objects/impls/tombstone.rs
@@ -5,4 +5,14 @@ simple_accessors! {
     (creep -> creep -> Creep),
     (death_time -> deathTime -> u32),
     (ticks_to_decay -> ticksToDecay -> u32),
+    (id -> id -> String)
 }
+
+impl PartialEq for Tombstone {
+    #[inline]
+    fn eq(&self, other: &Tombstone) -> bool{
+        self.id() == other.id()
+    }
+}
+
+impl Eq for Tombstone {}

--- a/screeps-game-api/src/objects/impls/tombstone.rs
+++ b/screeps-game-api/src/objects/impls/tombstone.rs
@@ -9,7 +9,6 @@ simple_accessors! {
 }
 
 impl PartialEq for Tombstone {
-    #[inline]
     fn eq(&self, other: &Tombstone) -> bool{
         self.id() == other.id()
     }

--- a/screeps-game-api/src/objects/macros.rs
+++ b/screeps-game-api/src/objects/macros.rs
@@ -88,21 +88,23 @@ macro_rules! impl_room_object_properties {
 }
 
 
-// Macro for mass implementing `StructureProperties`, `PartialEq` and `Eq` for a type. 
-// 
-// This macro accepts a comma-separated list of types on which to implement the unsafe `StructureProperties` trait on
-// a screeps object. 
-// From that implementation, the type gets the `id` method which is used to implement `PartialEq` and `Eq`.
-// 
-// # Example
-// ```
-// macro_rules!(OwnedStructure, Structure, StructureContainer)
-// ```
-// 
-// # Safety
-// The macro assumes that it is implementing the trait to a valid `Reference` 
-// (See `reference_wrapper` macro) which will support all `StructureProperties` methods.
-// 
+/// Macro for mass implementing `StructureProperties`, `PartialEq` and `Eq` for a type. 
+/// 
+/// Macro syntax:
+/// impl_structure_properties!{
+///     $struct1,
+///     $struct2,
+///     ...
+/// }
+/// 
+/// This macro accepts a comma-separated list of types on which to implement the unsafe `StructureProperties` trait on
+/// a screeps object. 
+/// From that implementation, the type gets the `id` method which is used to implement `PartialEq` and `Eq`.
+/// 
+/// # Safety
+/// The macro assumes that it is implementing the trait to a valid `Reference` 
+/// (See `reference_wrapper` macro) which will support all `StructureProperties` methods.
+/// 
 macro_rules! impl_structure_properties {
     ( $( $struct_name:ty ),+ ) => {$(
         unsafe impl StructureProperties for $struct_name {}

--- a/screeps-game-api/src/objects/macros.rs
+++ b/screeps-game-api/src/objects/macros.rs
@@ -86,3 +86,19 @@ macro_rules! impl_room_object_properties {
         )*
     );
 }
+
+
+macro_rules! impl_structure_properties {
+    ( $( $struct_name:ty ),+ ) => {$(
+        unsafe impl StructureProperties for $struct_name {}
+        
+        impl PartialEq for $struct_name {
+            #[inline]
+            fn eq(&self, other: &$struct_name) -> bool{
+                self.id() == other.id()
+            }
+        }
+
+        impl Eq for $struct_name {}
+    )*};
+}

--- a/screeps-game-api/src/objects/macros.rs
+++ b/screeps-game-api/src/objects/macros.rs
@@ -88,6 +88,21 @@ macro_rules! impl_room_object_properties {
 }
 
 
+// Macro for mass implementing `StructureProperties`, `PartialEq` and `Eq` for a type. 
+// 
+// This macro accepts a comma-separated list of types on which to implement the unsafe `StructureProperties` trait on
+// a screeps object. 
+// From that implementation, the type gets the `id` method which is used to implement `PartialEq` and `Eq`.
+// 
+// # Example
+// ```
+// macro_rules!(OwnedStructure, Structure, StructureContainer)
+// ```
+// 
+// # Safety
+// The macro assumes that it is implementing the trait to a valid `Reference` 
+// (See `reference_wrapper` macro) which will support all `StructureProperties` methods.
+// 
 macro_rules! impl_structure_properties {
     ( $( $struct_name:ty ),+ ) => {$(
         unsafe impl StructureProperties for $struct_name {}

--- a/screeps-game-api/src/objects/macros.rs
+++ b/screeps-game-api/src/objects/macros.rs
@@ -93,7 +93,6 @@ macro_rules! impl_structure_properties {
         unsafe impl StructureProperties for $struct_name {}
         
         impl PartialEq for $struct_name {
-            #[inline]
             fn eq(&self, other: &$struct_name) -> bool{
                 self.id() == other.id()
             }

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -227,7 +227,7 @@ pub unsafe trait OwnedStructureProperties: StructureProperties {
     fn my(&self) -> bool {
         js_unwrap!(@{self.as_ref()}.my)
     }
-    fn owner(&self) -> Option<String> {
+    fn owner_name(&self) -> Option<String> {
         (js! {
             var self = @{self.as_ref()};
             if (self.owner) {

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -325,27 +325,29 @@ impl_room_object_properties! {
     Tombstone,
 }
 
-unsafe impl StructureProperties for OwnedStructure {}
-unsafe impl StructureProperties for Structure {}
-unsafe impl StructureProperties for StructureContainer {}
-unsafe impl StructureProperties for StructureController {}
-unsafe impl StructureProperties for StructureExtension {}
-unsafe impl StructureProperties for StructureExtractor {}
-unsafe impl StructureProperties for StructureKeeperLair {}
-unsafe impl StructureProperties for StructureLab {}
-unsafe impl StructureProperties for StructureLink {}
-unsafe impl StructureProperties for StructureNuker {}
-unsafe impl StructureProperties for StructureObserver {}
-unsafe impl StructureProperties for StructurePowerBank {}
-unsafe impl StructureProperties for StructurePowerSpawn {}
-unsafe impl StructureProperties for StructurePortal {}
-unsafe impl StructureProperties for StructureRampart {}
-unsafe impl StructureProperties for StructureRoad {}
-unsafe impl StructureProperties for StructureSpawn {}
-unsafe impl StructureProperties for StructureStorage {}
-unsafe impl StructureProperties for StructureTerminal {}
-unsafe impl StructureProperties for StructureTower {}
-unsafe impl StructureProperties for StructureWall {}
+impl_structure_properties!{
+    OwnedStructure,
+    Structure,
+    StructureContainer,
+    StructureController,
+    StructureExtension,
+    StructureExtractor,
+    StructureKeeperLair,
+    StructureLab,
+    StructureLink,
+    StructureNuker,
+    StructureObserver,
+    StructurePowerBank,
+    StructurePowerSpawn,
+    StructurePortal,
+    StructureRampart,
+    StructureRoad,
+    StructureSpawn,
+    StructureStorage,
+    StructureTerminal,
+    StructureTower,
+    StructureWall
+}
 
 unsafe impl OwnedStructureProperties for OwnedStructure {}
 unsafe impl OwnedStructureProperties for StructureController {}


### PR DESCRIPTION
This PR adds methods to fetch `id`s on the object where this was missing.

Given those, it also implements `PartialEq` and `Eq` for all objects with an id.
Finally, it also adds `PartialEq` and `Eq` for `Room` based on name.

All of this for partitioning creeps by rooms...