### PR TITLE
findClosestByRange returns an object, not an array

### DIFF
--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -55,7 +55,7 @@ impl TryFrom<Value> for ReturnCode {
 }
 
 pub unsafe trait FindConstant {
-    type Item: TryFrom<Value, Error = <Reference as TryFrom<Value>>::Error>;
+    type Item: TryFrom<Value, Error = <Reference as TryFrom<Value>>::Error> + AsRef<Reference>;
 
     fn find_code(&self) -> i32;
 }

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -54,11 +54,11 @@ impl RoomPosition {
             .expect("expected Flag.createFlag to return ReturnCode")
     }
 
-    pub fn find_closest_by_range<T>(&self, ty: T) -> Vec<T::Item>
+    pub fn find_closest_by_range<T>(&self, ty: T) -> T::Item
     where
         T: FindConstant,
     {
-        js_unwrap_array!(@{self.as_ref()}.findClosestByRange(
+        js_unwrap!(@{self.as_ref()}.findClosestByRange(
             __structure_type_num_to_str(@{ty.find_code()}
         )))
     }

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -58,9 +58,9 @@ impl RoomPosition {
     where
         T: FindConstant,
     {
-        js!(@{self.as_ref()}.findClosestByRange(
-            __structure_type_num_to_str(@{ty.find_code()})
-            )).try_into().ok()
+        js_unwrap!(@{self.as_ref()}.findClosestByRange(
+            __structure_type_num_to_str(@{ty.find_code()}))
+        )
     }
 
     pub fn find_in_range<T>(&self, ty: T, range: i32) -> Vec<T::Item>

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -54,13 +54,13 @@ impl RoomPosition {
             .expect("expected Flag.createFlag to return ReturnCode")
     }
 
-    pub fn find_closest_by_range<T>(&self, ty: T) -> T::Item
+    pub fn find_closest_by_range<T>(&self, ty: T) -> Option<T::Item>
     where
         T: FindConstant,
     {
-        js_unwrap!(@{self.as_ref()}.findClosestByRange(
-            __structure_type_num_to_str(@{ty.find_code()}
-        )))
+        js!(@{self.as_ref()}.findClosestByRange(
+            __structure_type_num_to_str(@{ty.find_code()})
+            )).try_into().ok()
     }
 
     pub fn find_in_range<T>(&self, ty: T, range: i32) -> Vec<T::Item>


### PR DESCRIPTION
Unless I am mistaken from the doc, `findClosestByRange()` returns an object, not an array of objects.

https://docs.screeps.com/api/#RoomPosition.findClosestByRange