### PR TITLE
Accept &str as an input to raw_memory::get

### DIFF
--- a/screeps-game-api/src/raw_memory.rs
+++ b/screeps-game-api/src/raw_memory.rs
@@ -47,7 +47,7 @@ pub fn set_public_segments(ids: &[i32]) {
 
 get_from_js!(get() -> {RawMemory.get()} -> String);
 
-pub fn set(value: String) {
+pub fn set(value: &str) {
     js!{
         RawMemory.set(@{value});
     }


### PR DESCRIPTION
Just an API niceness since we don't need to own the string. The value will need to be copied anyways when sending to JavaScript, so we might as well accept a borrowed string.

CC #17. I'd forgotten about this detail before.