### PR TITLE
Switch `TryFrom` implementations to type check and add ExpectedType traits for non-typechecking conversions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ install:
 script:
 - (cd cargo-screeps && cargo build --verbose)
 - (cd cargo-screeps && cargo test --verbose)
+- (cd cargo-screeps && cargo build --all-features --verbose)
+- (cd cargo-screeps && cargo test --all-features --verbose)
 - (cd screeps-game-api && cargo build --release --target=wasm32-unknown-unknown --verbose)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,8 @@ install:
 test_script:
 - cd cargo-screeps && cargo build --verbose
 - cd cargo-screeps && cargo test --verbose
+- cd cargo-screeps && cargo build --all features --verbose
+- cd cargo-screeps && cargo test --all features --verbose
 - cd screeps-game-api && cargo build --release --target=wasm32-unknown-unknown --verbose
 
 cache:

--- a/screeps-game-api/Cargo.toml
+++ b/screeps-game-api/Cargo.toml
@@ -17,9 +17,13 @@ name = "screeps"
 
 [dependencies]
 stdweb = "0.4"
+stdweb-derive = "0.5"
 log = "0.4"
 enum_primitive = "0.1"
 num-traits = "0.2"
 serde = "1"
 serde_derive = "1"
 scoped-tls = "0.1"
+
+[features]
+check-all-casts = []

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -4,10 +4,7 @@
 use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::{Reference, Value};
 
-use {
-    objects::{FromExpectedType, RoomObject},
-    ConversionError,
-};
+use {objects::RoomObject, traits::FromExpectedType, ConversionError};
 
 enum_from_primitive! {
     #[repr(i32)]
@@ -323,7 +320,7 @@ pub mod look {
     use stdweb::unstable::TryInto;
 
     use {
-        objects::IntoExpectedType, ConstructionSite, Creep, Flag, Mineral, Nuke, Resource, Source,
+        traits::IntoExpectedType, ConstructionSite, Creep, Flag, Mineral, Nuke, Resource, Source,
         Structure, Terrain, Tombstone,
     };
 

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -320,11 +320,10 @@ pub unsafe trait LookConstant {
 }
 
 pub mod look {
-    use stdweb::unstable::TryInto;
-
     use {
-        traits::IntoExpectedType, ConstructionSite, Creep, Flag, Mineral, Nuke, Resource, Source,
-        Structure, Terrain, Tombstone,
+        traits::{IntoExpectedType, TryInto},
+        ConstructionSite, Creep, Flag, Mineral, Nuke, Resource, Source, Structure, Terrain,
+        Tombstone,
     };
 
     use super::{Look, LookConstant};

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -4,7 +4,10 @@
 use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::{Reference, Value};
 
-use {objects::RoomObject, ConversionError};
+use {
+    objects::{FromExpectedType, RoomObject},
+    ConversionError,
+};
 
 enum_from_primitive! {
     #[repr(i32)]
@@ -63,7 +66,7 @@ impl TryFrom<i32> for ReturnCode {
 }
 
 pub unsafe trait FindConstant {
-    type Item: TryFrom<Value, Error = ConversionError> + AsRef<Reference>;
+    type Item: FromExpectedType<Reference>;
 
     fn find_code(&self) -> i32;
 }
@@ -309,7 +312,9 @@ pub enum Look {
 }
 
 pub unsafe trait LookConstant {
-    type Item: TryFrom<Value, Error = ConversionError>;
+    type Item;
+
+    fn convert_and_check_items(reference: Value) -> Vec<Self::Item>;
 
     fn look_code(&self) -> Look;
 }
@@ -322,17 +327,18 @@ pub mod look {
     };
 
     typesafe_look_constants! {
-        CREEPS, Look::Creeps, Creep;
-        ENERGY, Look::Energy, Resource;
-        RESOURCES, Look::Resources, Resource;
-        SOURCES, Look::Sources, Source;
-        MINERALS, Look::Minerals, Mineral;
-        STRUCTURES, Look::Structures, Structure;
-        FLAGS, Look::Flags, Flag;
-        CONSTRUCTION_SITES, Look::ConstructionSites, ConstructionSite;
-        NUKES, Look::Nukes, Nuke;
-        TERRAIN, Look::Terrain, Terrain;
-        TOMBSTONES, Look::Tombstones, Tombstone;
+        CREEPS, Look::Creeps, Creep,  ::objects::IntoExpectedType::into_expected_type;
+        ENERGY, Look::Energy, Resource,  ::objects::IntoExpectedType::into_expected_type;
+        RESOURCES, Look::Resources, Resource,  ::objects::IntoExpectedType::into_expected_type;
+        SOURCES, Look::Sources, Source,  ::objects::IntoExpectedType::into_expected_type;
+        MINERALS, Look::Minerals, Mineral,  ::objects::IntoExpectedType::into_expected_type;
+        STRUCTURES, Look::Structures, Structure,  ::objects::IntoExpectedType::into_expected_type;
+        FLAGS, Look::Flags, Flag,  ::objects::IntoExpectedType::into_expected_type;
+        CONSTRUCTION_SITES, Look::ConstructionSites, ConstructionSite,
+             ::objects::IntoExpectedType::into_expected_type;
+        NUKES, Look::Nukes, Nuke,  ::objects::IntoExpectedType::into_expected_type;
+        TERRAIN, Look::Terrain, Terrain,  ::stdweb::unstable::TryInto::try_into;
+        TOMBSTONES, Look::Tombstones, Tombstone,  ::objects::IntoExpectedType::into_expected_type;
     }
 }
 

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -320,25 +320,28 @@ pub unsafe trait LookConstant {
 }
 
 pub mod look {
-    use super::{Look, LookConstant};
+    use stdweb::unstable::TryInto;
+
     use {
-        ConstructionSite, Creep, Flag, Mineral, Nuke, Resource, Source, Structure, Terrain,
-        Tombstone,
+        objects::IntoExpectedType, ConstructionSite, Creep, Flag, Mineral, Nuke, Resource, Source,
+        Structure, Terrain, Tombstone,
     };
 
+    use super::{Look, LookConstant};
+
     typesafe_look_constants! {
-        CREEPS, Look::Creeps, Creep,  ::objects::IntoExpectedType::into_expected_type;
-        ENERGY, Look::Energy, Resource,  ::objects::IntoExpectedType::into_expected_type;
-        RESOURCES, Look::Resources, Resource,  ::objects::IntoExpectedType::into_expected_type;
-        SOURCES, Look::Sources, Source,  ::objects::IntoExpectedType::into_expected_type;
-        MINERALS, Look::Minerals, Mineral,  ::objects::IntoExpectedType::into_expected_type;
-        STRUCTURES, Look::Structures, Structure,  ::objects::IntoExpectedType::into_expected_type;
-        FLAGS, Look::Flags, Flag,  ::objects::IntoExpectedType::into_expected_type;
+        CREEPS, Look::Creeps, Creep, IntoExpectedType::into_expected_type;
+        ENERGY, Look::Energy, Resource, IntoExpectedType::into_expected_type;
+        RESOURCES, Look::Resources, Resource, IntoExpectedType::into_expected_type;
+        SOURCES, Look::Sources, Source, IntoExpectedType::into_expected_type;
+        MINERALS, Look::Minerals, Mineral, IntoExpectedType::into_expected_type;
+        STRUCTURES, Look::Structures, Structure, IntoExpectedType::into_expected_type;
+        FLAGS, Look::Flags, Flag, IntoExpectedType::into_expected_type;
         CONSTRUCTION_SITES, Look::ConstructionSites, ConstructionSite,
-             ::objects::IntoExpectedType::into_expected_type;
-        NUKES, Look::Nukes, Nuke,  ::objects::IntoExpectedType::into_expected_type;
-        TERRAIN, Look::Terrain, Terrain,  ::stdweb::unstable::TryInto::try_into;
-        TOMBSTONES, Look::Tombstones, Tombstone,  ::objects::IntoExpectedType::into_expected_type;
+            IntoExpectedType::into_expected_type;
+        NUKES, Look::Nukes, Nuke, IntoExpectedType::into_expected_type;
+        TERRAIN, Look::Terrain, Terrain, TryInto::try_into;
+        TOMBSTONES, Look::Tombstones, Tombstone, IntoExpectedType::into_expected_type;
     }
 }
 

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -1,10 +1,13 @@
 //! Constants, most copied from [the game constants](https://github.com/screeps/common/blob/master/lib/constants.js).
 //!
 //! Last updated on 2018-03-06, `c3372fd` on https://github.com/screeps/common/commits/master/lib/constants.js.
-use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::{Reference, Value};
 
-use {objects::RoomObject, traits::FromExpectedType, ConversionError};
+use {
+    objects::RoomObject,
+    traits::{FromExpectedType, TryFrom, TryInto},
+    ConversionError,
+};
 
 enum_from_primitive! {
     #[repr(i32)]

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -126,10 +126,10 @@ pub mod gcl {
 /// [http://docs.screeps.com/api/#Game.map]: http://docs.screeps.com/api/#Game.map
 pub mod map {
     use std::collections;
-    use stdweb::unstable::{TryInto, TryFrom};
 
-    use {Direction, RoomPosition, Terrain, Room};
-    use constants::{ReturnCode, find::Exit};
+    use constants::{find::Exit, ReturnCode};
+    use traits::{TryFrom, TryInto};
+    use {Direction, Room, RoomPosition, Terrain};
 
     /// See [http://docs.screeps.com/api/#Game.map.describeExits]
     ///

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -1,5 +1,4 @@
-use stdweb::unstable::TryInto;
-
+use traits::TryInto;
 use {RoomObjectProperties, ConversionError, RoomObject};
 
 // TODO: split these out into separate files once we add documentation.

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -1,3 +1,7 @@
+use stdweb::unstable::TryInto;
+
+use {RoomObjectProperties, ConversionError, RoomObject};
+
 // TODO: split these out into separate files once we add documentation.
 //
 // Right now, they can all fit in here because they're pretty small.
@@ -417,8 +421,25 @@ pub fn time() -> u32 {
 
 /// See [http://docs.screeps.com/api/#Game.getObjectById]
 ///
+/// This gets an object expecting a specific type and will return a `ConversionError` if the type
+/// does not match.
+///
+/// If all you want to assume is that something has an ID, use [`get_object_erased`].
 /// [http://docs.screeps.com/api/#Game.getObjectById]: http://docs.screeps.com/api/#Game.getObjectById
-pub fn get_object(id: &str) -> Option<::objects::RoomObject> {
+pub fn get_object_typed<T>(id: &str) -> Result<Option<T>, ConversionError>
+where
+    T: RoomObjectProperties,
+{
+    js!(return Game.getObjectById(@{id});).try_into()
+}
+
+/// See [http://docs.screeps.com/api/#Game.getObjectById]
+///
+/// This gets the object in 'erased' form - all that is known about it is that it's a RoomObject.
+///
+/// If a more specific type is expected, [`get_object_typed`] can be used.
+/// [http://docs.screeps.com/api/#Game.getObjectById]: http://docs.screeps.com/api/#Game.getObjectById
+pub fn get_object_erased(id: &str) -> Option<RoomObject> {
     js_unwrap_ref!(Game.getObjectById(@{id}))
 }
 

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -419,7 +419,7 @@ pub fn time() -> u32 {
 ///
 /// [http://docs.screeps.com/api/#Game.getObjectById]: http://docs.screeps.com/api/#Game.getObjectById
 pub fn get_object(id: &str) -> Option<::objects::RoomObject> {
-    js_unwrap!(Game.getObjectById(@{id}))
+    js_unwrap_ref!(Game.getObjectById(@{id}))
 }
 
 pub fn notify(message: &str, group_interval: Option<u32>) {

--- a/screeps-game-api/src/lib.rs
+++ b/screeps-game-api/src/lib.rs
@@ -43,10 +43,12 @@ pub mod objects;
 pub mod pathfinder;
 mod positions;
 pub mod raw_memory;
+pub mod traits;
 
 pub use constants::*;
 pub use objects::*;
 pub use positions::{LocalRoomName, LocalRoomPosition};
+pub use traits::{FromExpectedType, IntoExpectedType};
 
 pub(crate) use stdweb::private::ConversionError;
 

--- a/screeps-game-api/src/lib.rs
+++ b/screeps-game-api/src/lib.rs
@@ -1,3 +1,22 @@
+//! `screeps-game-api`
+//!
+//! # Cargo Features
+//!
+//! ## `check-all-casts`
+//!
+//! By default, `screeps-game-api` assumes that the Screeps JavaScript API calls return the types
+//! that they are documented to return and bypasses `instanceof` checks when constructing rust
+//! wrappers for those return values.
+//!
+//! To enable checking all types on all API calls, even ones when the screeps server reliably
+//! returns the expected type, depend on `screeps-game-api` with the `"check-all-casts"` feature
+//! flag:
+//!
+//! ```toml
+//! [dependencies]
+//! # ...
+//! screeps-game-api = { version = "0.2", features = ["check-all-casts"] }
+//! ```
 #![recursion_limit = "128"]
 #[macro_use]
 extern crate enum_primitive;
@@ -11,6 +30,8 @@ extern crate serde;
 extern crate serde_derive;
 #[macro_use]
 extern crate stdweb;
+#[macro_use]
+extern crate stdweb_derive;
 
 #[macro_use]
 mod macros;

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -134,10 +134,20 @@ macro_rules! get_from_js {
 /// ```
 ///
 /// Screeps game objects, in javascript, can be accessed via stdweb's `Reference`
-/// object. This macro: 
-///   - Creates a struct named `objX`;
-///   - Implements traits `AsRef<Reference>`, `TryFrom<Value>` for `objX`
-///   - Implements trait `From<objX>` for `Reference`
+/// object. For each ident `objJ` mentioned, this macro:
+///
+/// - Creates a struct named `objX`;
+/// - Uses `#[derive(Clone, ReferenceType)]` which implements these traits for `objX`:
+///   - InstanceOf
+///   - AsRef<Reference>
+///   - ReferenceType
+///   - Into<Reference>
+///   - TryInto<Reference>
+///   - TryFrom<Reference>
+///   - TryFrom<&Reference>
+///   - TryFrom<Value>
+///   - TryFrom<&Value>
+/// - Implements FromExpectedType<Reference> for `objJ`
 macro_rules! reference_wrappers {
     (
         $(

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -119,31 +119,6 @@ macro_rules! get_from_js {
     )
 }
 
-/// Creates a getter macro to retrieve a field of a JavaScript wrapping struct.
-///
-/// The main difference between this and [`get_from_js!`] is that this calls
-/// [`js_unwrap_ref!`] whereas [`get_from_js!`] calls [`js_unwrap!`].
-///
-/// See [`get_from_js!`] for more information.
-macro_rules! get_ref_from_js {
-    ($name:ident -> { $js_side:expr } -> $rust_ret_type:ty) => (
-        get_from_js!($name() -> { $js_side } -> $rust_ret_type);
-    );
-    (
-        $name:ident(
-            $($param_ident:ident: $param_ty:ty),*
-        ) -> {
-            $($js_side:tt)*
-        } -> $rust_ret_type:ty
-    ) => (
-        pub fn $name(
-            $($param_ident: $param_ty),*
-        ) -> $rust_ret_type {
-            js_unwrap_ref!($($js_side)*)
-        }
-    )
-}
-
 /// Macro used to encapsulate all screeps game objects
 ///
 /// Macro syntax:

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -166,7 +166,7 @@ macro_rules! reference_wrappers {
                 fn from_expected_type(reference: Reference) -> Result<Self, ConversionError> {
                     #[cfg(feature = "check-all-casts")]
                     {
-                        ::stdweb::unstable::TryFrom::try_from(reference)
+                        ::traits::TryFrom::try_from(reference)
                     }
                     #[cfg(not(feature = "check-all-casts"))]
                     {

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -239,31 +239,6 @@ macro_rules! simple_accessors {
     )
 }
 
-/// Implements the unsafe trait RoomObjectProperties for a Structure struct 
-/// 
-/// Macro Syntax: 
-/// impl_room_object_properties!{
-///     $structure1,
-///     $structure2,
-///     ...
-/// }
-macro_rules! impl_room_object_properties {
-    ($($struct_name:ident),* $(,)*) => {
-        $(
-            unsafe impl RoomObjectProperties for $struct_name {
-                fn try_from(obj: RoomObject) -> Option<Self> {
-                    let is_me = js_unwrap!(@{obj.as_ref()} instanceof $struct_name);
-                    if is_me {
-                        Some($struct_name(obj.0))
-                    } else {
-                        None
-                    }
-                }
-            }
-        )*
-    };
-}
-
 /// Macro for mass implementing `StructureProperties`, `PartialEq` and `Eq` for a type. 
 /// 
 /// Macro syntax:

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -45,7 +45,7 @@
 /// Note: for unwrapping reference types, use [`js_unwrap_ref!`] to avoid instanceof checks.
 macro_rules! js_unwrap {
     ($($code:tt)*) => (
-        ::stdweb::unstable::TryInto::try_into(js! { return $($code)*; })
+        ::traits::TryInto::try_into(js! { return $($code)*; })
             .expect(concat!("js_unwrap at ", line!(), " in ", file!()))
     )
 }

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -152,25 +152,19 @@ macro_rules! reference_wrappers {
             )*
             pub struct $name(Reference);
 
-            impl_cast_expected_reference!($name);
-        )*
-    };
-}
-
-macro_rules! impl_cast_expected_reference {
-    ($name:ident) => {
-        impl FromExpectedType<Reference> for $name {
-            fn from_expected_type(reference: Reference) -> Result<Self, ConversionError> {
-                #[cfg(feature = "check-all-casts")]
-                {
-                    ::stdweb::unstable::TryFrom::try_from(reference)
-                }
-                #[cfg(not(feature = "check-all-casts"))]
-                {
-                    unsafe { Ok(::stdweb::ReferenceType::from_reference_unchecked(reference)) }
+            impl FromExpectedType<Reference> for $name {
+                fn from_expected_type(reference: Reference) -> Result<Self, ConversionError> {
+                    #[cfg(feature = "check-all-casts")]
+                    {
+                        ::stdweb::unstable::TryFrom::try_from(reference)
+                    }
+                    #[cfg(not(feature = "check-all-casts"))]
+                    {
+                        unsafe { Ok(::stdweb::ReferenceType::from_reference_unchecked(reference)) }
+                    }
                 }
             }
-        }
+        )*
     };
 }
 

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -410,12 +410,12 @@ macro_rules! game_map_access {
 
                 /// Retrieve all values in this object.
                 pub fn values() -> Vec<$type> {
-                    js_unwrap!(Object.values($js_inner))
+                    js_unwrap_ref!(Object.values($js_inner))
                 }
 
                 /// Retrieve a specific value by key.
                 pub fn get(name: &str) -> Option<$type> {
-                    js_unwrap!($js_inner[@{name}])
+                    js_unwrap_ref!($js_inner[@{name}])
                 }
             }
         )*

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -388,6 +388,61 @@ macro_rules! game_map_access {
     };
 }
 
+/// Match on all variants of `Structure` and do the same thing for each of them.
+macro_rules! match_structure_variants {
+    ($source:expr, $name:ident => $action:expr) => {
+        match $source {
+            Structure::Container($name) => $action,
+            Structure::Controller($name) => $action,
+            Structure::Extension($name) => $action,
+            Structure::Extractor($name) => $action,
+            Structure::KeeperLair($name) => $action,
+            Structure::Lab($name) => $action,
+            Structure::Link($name) => $action,
+            Structure::Nuker($name) => $action,
+            Structure::Observer($name) => $action,
+            Structure::PowerBank($name) => $action,
+            Structure::PowerSpawn($name) => $action,
+            Structure::Portal($name) => $action,
+            Structure::Rampart($name) => $action,
+            Structure::Road($name) => $action,
+            Structure::Spawn($name) => $action,
+            Structure::Storage($name) => $action,
+            Structure::Terminal($name) => $action,
+            Structure::Tower($name) => $action,
+            Structure::Wall($name) => $action,
+        }
+    }
+}
+
+/// Match on all variants of `StructureType` and construct `Structure` variants from
+/// the same code for each of them.
+macro_rules! construct_structure_variants {
+    ($source:expr => $action:expr) => {
+        match $source {
+            StructureType::Container => Structure::Container($action),
+            StructureType::Controller => Structure::Controller($action),
+            StructureType::Extension => Structure::Extension($action),
+            StructureType::Extractor => Structure::Extractor($action),
+            StructureType::KeeperLair => Structure::KeeperLair($action),
+            StructureType::Lab => Structure::Lab($action),
+            StructureType::Link => Structure::Link($action),
+            StructureType::Nuker => Structure::Nuker($action),
+            StructureType::Observer => Structure::Observer($action),
+            StructureType::PowerBank => Structure::PowerBank($action),
+            StructureType::PowerSpawn => Structure::PowerSpawn($action),
+            StructureType::Portal => Structure::Portal($action),
+            StructureType::Rampart => Structure::Rampart($action),
+            StructureType::Road => Structure::Road($action),
+            StructureType::Spawn => Structure::Spawn($action),
+            StructureType::Storage => Structure::Storage($action),
+            StructureType::Terminal => Structure::Terminal($action),
+            StructureType::Tower => Structure::Tower($action),
+            StructureType::Wall => Structure::Wall($action),
+        }
+    }
+}
+
 /// Get a value from memory given a path, returning `None` if any thing along the way does not
 /// exist.
 ///

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -70,7 +70,7 @@ macro_rules! js_unwrap {
 /// [`screeps::Creep`] containing the wrong value which will fail when used.
 macro_rules! js_unwrap_ref {
     ($($code:tt)*) => (
-        ::objects::IntoExpectedType::into_expected_type(js! { return $($code)*; })
+        ::traits::IntoExpectedType::into_expected_type(js! { return $($code)*; })
             .expect(concat!("js_unwrap_ref at ", line!(), " in ", file!()))
     )
 }
@@ -152,7 +152,7 @@ macro_rules! reference_wrappers {
             )*
             pub struct $name(Reference);
 
-            impl FromExpectedType<Reference> for $name {
+            impl ::traits::FromExpectedType<Reference> for $name {
                 fn from_expected_type(reference: Reference) -> Result<Self, ConversionError> {
                     #[cfg(feature = "check-all-casts")]
                     {

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -70,7 +70,7 @@ macro_rules! js_unwrap {
 /// [`screeps::Creep`] containing the wrong value which will fail when used.
 macro_rules! js_unwrap_ref {
     ($($code:tt)*) => (
-        ::objects::IntoExpectedType::into_expected_type(js! { return $($code)* })
+        ::objects::IntoExpectedType::into_expected_type(js! { return $($code)*; })
             .expect(concat!("js_unwrap_ref at ", line!(), " in ", file!()))
     )
 }

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -310,13 +310,19 @@ macro_rules! typesafe_find_constants {
 
 macro_rules! typesafe_look_constants {
     (
-        $($constant_name:ident, $value:expr, $result:path;)*
+        $($constant_name:ident, $value:expr, $result:path, $conversion_method:expr;)*
     ) => (
         $(
             #[allow(bad_style)]
             pub struct $constant_name;
             unsafe impl LookConstant for $constant_name {
                 type Item = $result;
+
+                fn convert_and_check_items(reference: ::stdweb::Value) -> Vec<Self::Item> {
+                    ($conversion_method)(reference)
+                        .expect(concat!("LookConstant ", stringify!($constant_name),
+                               "expected correct type at ", line!(), " in ", file!()))
+                }
 
                 fn look_code(&self) -> Look {
                     $value

--- a/screeps-game-api/src/memory.rs
+++ b/screeps-game-api/src/memory.rs
@@ -52,10 +52,12 @@
 //! 
 
 use std::fmt;
-use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::{JsSerialize, Reference, Value};
 
-use ConversionError;
+use {
+    traits::{TryFrom, TryInto},
+    ConversionError,
+};
 
 #[derive(Clone, Debug)]
 pub struct UnexpectedTypeError;

--- a/screeps-game-api/src/objects/impls/construction_site.rs
+++ b/screeps-game-api/src/objects/impls/construction_site.rs
@@ -1,6 +1,4 @@
-use stdweb::unstable::TryInto;
-
-use {ReturnCode, StructureType};
+use {traits::TryInto, ReturnCode, StructureType};
 
 // TODO: Use root import after https://github.com/rust-lang/rust/issues/53140 is fixed.
 use super::super::ConstructionSite;

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -6,7 +6,6 @@ use std::{
 
 use stdweb::{
     Reference,
-    unstable::TryInto,
 };
 
 use constants::{
@@ -29,6 +28,7 @@ use objects::{
 };
 use pathfinder::CostMatrix;
 use positions::LocalRoomName;
+use traits::TryInto;
 
 simple_accessors! {
     Room;

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -103,7 +103,7 @@ impl Room {
     where
         T: FindConstant,
     {
-        js_unwrap!(@{self.as_ref()}.find(@{ty.find_code()}))
+        js_unwrap_ref!(@{self.as_ref()}.find(@{ty.find_code()}))
     }
 
     pub fn find_exit_to(&self, room: &Room) -> Result<Exit, ReturnCode> {
@@ -218,10 +218,10 @@ impl Room {
         U: HasPosition,
     {
         let pos = target.pos();
-        js_unwrap!(@{self.as_ref()}.lookForAt(
+        T::convert_and_check_items(js_unwrap!(@{self.as_ref()}.lookForAt(
             __look_num_to_str(@{ty.look_code() as i32}),
             @{pos.as_ref()}
-        ))
+        )))
     }
 
     /// Looks for a given thing over a given area of bounds.
@@ -255,14 +255,14 @@ impl Room {
         assert!(horiz.end <= 50);
         assert!(vert.end <= 50);
 
-        js_unwrap!(@{self.as_ref()}.lookForAtArea(
+        T::convert_and_check_items(js_unwrap!{@{self.as_ref()}.lookForAtArea(
             __look_num_to_str(@{ty.look_code() as i32}),
             @{vert.start},
             @{horiz.start},
             @{vert.end},
             @{horiz.end},
             true
-        ).map((obj) => obj[__look_num_to_str(@{ty.look_code() as i32})]))
+        ).map((obj) => obj[__look_num_to_str(@{ty.look_code() as i32})])})
     }
 
     pub fn memory(&self) -> MemoryReference {

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -3,8 +3,6 @@ use std::cmp::{
     PartialEq
 };
 
-use stdweb::unstable::TryInto;
-
 use {
     constants::{
         Color, 
@@ -23,6 +21,7 @@ use {
     },
     pathfinder::CostMatrix,
     positions::LocalRoomPosition,
+    traits::TryInto,
 };
 
 impl RoomPosition {

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -73,7 +73,7 @@ impl RoomPosition {
     where
         T: FindConstant,
     {
-        js_unwrap!(@{self.as_ref()}.findClosestByRange(
+        js_unwrap_ref!(@{self.as_ref()}.findClosestByRange(
             __structure_type_num_to_str(@{ty.find_code()}))
         )
     }
@@ -82,7 +82,7 @@ impl RoomPosition {
     where
         T: FindConstant,
     {
-        js_unwrap!(@{self.as_ref()}.findInRange(
+        js_unwrap_ref!(@{self.as_ref()}.findInRange(
             __structure_type_num_to_str(@{ty.find_code()}),
             @{range}
         ))
@@ -148,7 +148,9 @@ impl RoomPosition {
     where
         T: LookConstant,
     {
-        js_unwrap!(@{self.as_ref()}.lookFor(__look_num_to_str(@{ty.look_code() as i32})))
+        T::convert_and_check_items(js_unwrap!{
+            @{self.as_ref()}.lookFor(__look_num_to_str(@{ty.look_code() as i32}))
+        })
     }
 }
 

--- a/screeps-game-api/src/objects/impls/structure_portal.rs
+++ b/screeps-game-api/src/objects/impls/structure_portal.rs
@@ -1,6 +1,5 @@
-use stdweb::unstable::TryInto;
-
 use {
+    traits::TryInto,
     {RoomPosition, StructurePortal},
 };
 

--- a/screeps-game-api/src/objects/impls/structure_spawn.rs
+++ b/screeps-game-api/src/objects/impls/structure_spawn.rs
@@ -1,8 +1,8 @@
-use stdweb::unstable::TryInto;
 use stdweb::Reference;
 
 use memory::MemoryReference;
 use objects::StructureSpawn;
+use traits::TryInto;
 
 use {Direction, Part, ReturnCode, StructureProperties, Creep};
 

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -236,16 +236,6 @@ impl TryFrom<Value> for Structure {
     }
 }
 
-unsafe impl RoomObjectProperties for Structure {
-    fn try_from(obj: RoomObject) -> Option<Self> {
-        let is_me = js_unwrap!(@{obj.as_ref()} instanceof Structure);
-        if is_me {
-            Some(Self::from_reference(obj.0))
-        } else {
-            None
-        }
-    }
-}
 
 /// Trait for casting api results which we expect to be the right thing as long as all JS code is
 /// behaving as expected.
@@ -312,8 +302,6 @@ where
 pub unsafe trait RoomObjectProperties:
     AsRef<Reference> + Into<Reference> + HasPosition
 {
-    fn try_from(obj: RoomObject) -> Option<Self>;
-
     fn room(&self) -> Room {
         js_unwrap!(@{self.as_ref()}.room)
     }
@@ -530,37 +518,36 @@ unsafe impl Attackable for StructureTerminal {}
 unsafe impl Attackable for StructureTower {}
 unsafe impl Attackable for StructureWall {}
 
-impl_room_object_properties! {
-    ConstructionSite,
-    Creep,
-    Flag,
-    Mineral,
-    Nuke,
-    OwnedStructure,
-    Resource,
-    RoomObject,
-    Source,
-    StructureContainer,
-    StructureController,
-    StructureExtension,
-    StructureExtractor,
-    StructureKeeperLair,
-    StructureLab,
-    StructureLink,
-    StructureNuker,
-    StructureObserver,
-    StructurePowerBank,
-    StructurePowerSpawn,
-    StructurePortal,
-    StructureRampart,
-    StructureRoad,
-    StructureSpawn,
-    StructureStorage,
-    StructureTerminal,
-    StructureTower,
-    StructureWall,
-    Tombstone,
-}
+unsafe impl RoomObjectProperties for ConstructionSite {}
+unsafe impl RoomObjectProperties for Creep {}
+unsafe impl RoomObjectProperties for Flag {}
+unsafe impl RoomObjectProperties for Mineral {}
+unsafe impl RoomObjectProperties for Nuke {}
+unsafe impl RoomObjectProperties for OwnedStructure {}
+unsafe impl RoomObjectProperties for Resource {}
+unsafe impl RoomObjectProperties for RoomObject {}
+unsafe impl RoomObjectProperties for Source {}
+unsafe impl RoomObjectProperties for StructureContainer {}
+unsafe impl RoomObjectProperties for StructureController {}
+unsafe impl RoomObjectProperties for StructureExtension {}
+unsafe impl RoomObjectProperties for StructureExtractor {}
+unsafe impl RoomObjectProperties for StructureKeeperLair {}
+unsafe impl RoomObjectProperties for StructureLab {}
+unsafe impl RoomObjectProperties for StructureLink {}
+unsafe impl RoomObjectProperties for StructureNuker {}
+unsafe impl RoomObjectProperties for StructureObserver {}
+unsafe impl RoomObjectProperties for StructurePowerBank {}
+unsafe impl RoomObjectProperties for StructurePowerSpawn {}
+unsafe impl RoomObjectProperties for StructurePortal {}
+unsafe impl RoomObjectProperties for StructureRampart {}
+unsafe impl RoomObjectProperties for StructureRoad {}
+unsafe impl RoomObjectProperties for StructureSpawn {}
+unsafe impl RoomObjectProperties for StructureStorage {}
+unsafe impl RoomObjectProperties for StructureTerminal {}
+unsafe impl RoomObjectProperties for StructureTower {}
+unsafe impl RoomObjectProperties for StructureWall {}
+unsafe impl RoomObjectProperties for Structure {}
+unsafe impl RoomObjectProperties for Tombstone {}
 
 impl_structure_properties!{
     OwnedStructure,

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -118,6 +118,8 @@ pub enum Structure {
     Wall(StructureWall),
 }
 
+impl_cast_expected_reference!(Structure);
+
 impl AsRef<Reference> for Structure {
     fn as_ref(&self) -> &Reference {
         match *self {
@@ -166,6 +168,36 @@ impl From<Structure> for Reference {
             Structure::Tower(v) => v.0,
             Structure::Wall(v) => v.0,
         }
+    }
+}
+
+impl CastExpectedType<Structure> for Reference
+{
+    fn cast_expected_type(self) -> Result<Structure, ConversionError> {
+        let structure_type = js_unwrap!(@{&self}.structureType);
+        let structure = match structure_type {
+            StructureType::Container => Structure::Container(self.cast_expected_type()?),
+            StructureType::Controller => Structure::Controller(self.cast_expected_type()?),
+            StructureType::Extension => Structure::Extension(self.cast_expected_type()?),
+            StructureType::Extractor => Structure::Extractor(self.cast_expected_type()?),
+            StructureType::KeeperLair => Structure::KeeperLair(self.cast_expected_type()?),
+            StructureType::Lab => Structure::Lab(self.cast_expected_type()?),
+            StructureType::Link => Structure::Link(self.cast_expected_type()?),
+            StructureType::Nuker => Structure::Nuker(self.cast_expected_type()?),
+            StructureType::Observer => Structure::Observer(self.cast_expected_type()?),
+            StructureType::PowerBank => Structure::PowerBank(self.cast_expected_type()?),
+            StructureType::PowerSpawn => Structure::PowerSpawn(self.cast_expected_type()?),
+            StructureType::Portal => Structure::Portal(self.cast_expected_type()?),
+            StructureType::Rampart => Structure::Rampart(self.cast_expected_type()?),
+            StructureType::Road => Structure::Road(self.cast_expected_type()?),
+            StructureType::Spawn => Structure::Spawn(self.cast_expected_type()?),
+            StructureType::Storage => Structure::Storage(self.cast_expected_type()?),
+            StructureType::Terminal => Structure::Terminal(self.cast_expected_type()?),
+            StructureType::Tower => Structure::Tower(self.cast_expected_type()?),
+            StructureType::Wall => Structure::Wall(self.cast_expected_type()?),
+        };
+
+        Ok(structure)
     }
 }
 
@@ -229,15 +261,6 @@ pub(crate) trait CastExpectedType<T> {
     ///
     /// If this is a non-`Reference` `Value`, this will return an error.
     fn cast_expected_type(self) -> Result<T, ConversionError>;
-}
-
-impl<T> CastExpectedType<T> for Value
-where
-    Reference: CastExpectedType<T>,
-{
-    fn cast_expected_type(self) -> Result<T, ConversionError> {
-        Reference::try_from(self).and_then(|reference| reference.cast_expected_type())
-    }
 }
 
 impl<T> CastExpectedType<T> for Reference

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -13,7 +13,7 @@
 //! do anything mischievous, like removing properties from objects or sticking
 //! unexpected things into dictionaries which we trust.
 use stdweb::unstable::{TryFrom, TryInto};
-use stdweb::{Reference, Value};
+use stdweb::{Reference, ReferenceType, Value};
 
 use {ResourceType, ReturnCode, StructureType, ConversionError};
 
@@ -198,7 +198,12 @@ where
 /// The reference returned by `AsRef<Reference>::as_ref` must reference a
 /// JavaScript object extending the `RoomObject` class.
 pub unsafe trait RoomObjectProperties:
-    AsRef<Reference> + Into<Reference> + HasPosition
+    AsRef<Reference>
+    + Into<Reference>
+    + HasPosition
+    + ReferenceType
+    + TryFrom<Value, Error = ConversionError>
+    + TryFrom<Reference, Error = ConversionError>
 {
     fn room(&self) -> Room {
         js_unwrap_ref!(@{self.as_ref()}.room)

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -12,9 +12,9 @@
 //! rely on these contracts being upheld as long as JavaScript code does not
 //! do anything mischievous, like removing properties from objects or sticking
 //! unexpected things into dictionaries which we trust.
-use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::{Reference, ReferenceType, Value};
 
+use traits::{TryFrom, TryInto};
 use {ConversionError, IntoExpectedType, ResourceType, ReturnCode, StructureType};
 
 mod impls;

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -18,14 +18,18 @@ use stdweb::{Reference, Value};
 use {ResourceType, ReturnCode, StructureType, ConversionError};
 
 mod impls;
+mod structure;
 
-pub use self::impls::{
-    FindOptions,
-    Path,
-    Reservation, 
-    Sign, 
-    SpawnOptions,
-    Step, 
+pub use self::{
+    impls::{
+        FindOptions,
+        Path,
+        Reservation, 
+        Sign, 
+        SpawnOptions,
+        Step, 
+    },
+    structure::Structure,
 };
 
 reference_wrappers!(
@@ -95,143 +99,6 @@ reference_wrappers!(
     #[reference(instance_of = "Tombstone")]
     Tombstone,
 );
-
-pub enum Structure {
-    Container(StructureContainer),
-    Controller(StructureController),
-    Extension(StructureExtension),
-    Extractor(StructureExtractor),
-    KeeperLair(StructureKeeperLair),
-    Lab(StructureLab),
-    Link(StructureLink),
-    Nuker(StructureNuker),
-    Observer(StructureObserver),
-    PowerBank(StructurePowerBank),
-    PowerSpawn(StructurePowerSpawn),
-    Portal(StructurePortal),
-    Rampart(StructureRampart),
-    Road(StructureRoad),
-    Spawn(StructureSpawn),
-    Storage(StructureStorage),
-    Terminal(StructureTerminal),
-    Tower(StructureTower),
-    Wall(StructureWall),
-}
-
-impl AsRef<Reference> for Structure {
-    fn as_ref(&self) -> &Reference {
-        match *self {
-            Structure::Container(ref v) => v.as_ref(),
-            Structure::Controller(ref v) => v.as_ref(),
-            Structure::Extension(ref v) => v.as_ref(),
-            Structure::Extractor(ref v) => v.as_ref(),
-            Structure::KeeperLair(ref v) => v.as_ref(),
-            Structure::Lab(ref v) => v.as_ref(),
-            Structure::Link(ref v) => v.as_ref(),
-            Structure::Nuker(ref v) => v.as_ref(),
-            Structure::Observer(ref v) => v.as_ref(),
-            Structure::PowerBank(ref v) => v.as_ref(),
-            Structure::PowerSpawn(ref v) => v.as_ref(),
-            Structure::Portal(ref v) => v.as_ref(),
-            Structure::Rampart(ref v) => v.as_ref(),
-            Structure::Road(ref v) => v.as_ref(),
-            Structure::Spawn(ref v) => v.as_ref(),
-            Structure::Storage(ref v) => v.as_ref(),
-            Structure::Terminal(ref v) => v.as_ref(),
-            Structure::Tower(ref v) => v.as_ref(),
-            Structure::Wall(ref v) => v.as_ref(),
-        }
-    }
-}
-impl From<Structure> for Reference {
-    fn from(wrapper: Structure) -> Reference {
-        match wrapper {
-            Structure::Container(v) => v.0,
-            Structure::Controller(v) => v.0,
-            Structure::Extension(v) => v.0,
-            Structure::Extractor(v) => v.0,
-            Structure::KeeperLair(v) => v.0,
-            Structure::Lab(v) => v.0,
-            Structure::Link(v) => v.0,
-            Structure::Nuker(v) => v.0,
-            Structure::Observer(v) => v.0,
-            Structure::PowerBank(v) => v.0,
-            Structure::PowerSpawn(v) => v.0,
-            Structure::Portal(v) => v.0,
-            Structure::Rampart(v) => v.0,
-            Structure::Road(v) => v.0,
-            Structure::Spawn(v) => v.0,
-            Structure::Storage(v) => v.0,
-            Structure::Terminal(v) => v.0,
-            Structure::Tower(v) => v.0,
-            Structure::Wall(v) => v.0,
-        }
-    }
-}
-
-impl FromExpectedType<Reference> for Structure {
-    fn from_expected_type(reference: Reference) -> Result<Self, ConversionError> {
-        let structure_type = js_unwrap!(@{&reference}.structureType);
-        let structure = match structure_type {
-            StructureType::Container => Structure::Container(reference.into_expected_type()?),
-            StructureType::Controller => Structure::Controller(reference.into_expected_type()?),
-            StructureType::Extension => Structure::Extension(reference.into_expected_type()?),
-            StructureType::Extractor => Structure::Extractor(reference.into_expected_type()?),
-            StructureType::KeeperLair => Structure::KeeperLair(reference.into_expected_type()?),
-            StructureType::Lab => Structure::Lab(reference.into_expected_type()?),
-            StructureType::Link => Structure::Link(reference.into_expected_type()?),
-            StructureType::Nuker => Structure::Nuker(reference.into_expected_type()?),
-            StructureType::Observer => Structure::Observer(reference.into_expected_type()?),
-            StructureType::PowerBank => Structure::PowerBank(reference.into_expected_type()?),
-            StructureType::PowerSpawn => Structure::PowerSpawn(reference.into_expected_type()?),
-            StructureType::Portal => Structure::Portal(reference.into_expected_type()?),
-            StructureType::Rampart => Structure::Rampart(reference.into_expected_type()?),
-            StructureType::Road => Structure::Road(reference.into_expected_type()?),
-            StructureType::Spawn => Structure::Spawn(reference.into_expected_type()?),
-            StructureType::Storage => Structure::Storage(reference.into_expected_type()?),
-            StructureType::Terminal => Structure::Terminal(reference.into_expected_type()?),
-            StructureType::Tower => Structure::Tower(reference.into_expected_type()?),
-            StructureType::Wall => Structure::Wall(reference.into_expected_type()?),
-        };
-
-        Ok(structure)
-    }
-}
-
-impl Structure {
-    fn from_reference(reference: Reference) -> Self {
-        let s = js_unwrap!(@{&reference}.structureType);
-        match s {
-            StructureType::Container => Structure::Container(StructureContainer(reference)),
-            StructureType::Controller => Structure::Controller(StructureController(reference)),
-            StructureType::Extension => Structure::Extension(StructureExtension(reference)),
-            StructureType::Extractor => Structure::Extractor(StructureExtractor(reference)),
-            StructureType::KeeperLair => Structure::KeeperLair(StructureKeeperLair(reference)),
-            StructureType::Lab => Structure::Lab(StructureLab(reference)),
-            StructureType::Link => Structure::Link(StructureLink(reference)),
-            StructureType::Nuker => Structure::Nuker(StructureNuker(reference)),
-            StructureType::Observer => Structure::Observer(StructureObserver(reference)),
-            StructureType::PowerBank => Structure::PowerBank(StructurePowerBank(reference)),
-            StructureType::PowerSpawn => Structure::PowerSpawn(StructurePowerSpawn(reference)),
-            StructureType::Portal => Structure::Portal(StructurePortal(reference)),
-            StructureType::Rampart => Structure::Rampart(StructureRampart(reference)),
-            StructureType::Road => Structure::Road(StructureRoad(reference)),
-            StructureType::Spawn => Structure::Spawn(StructureSpawn(reference)),
-            StructureType::Storage => Structure::Storage(StructureStorage(reference)),
-            StructureType::Terminal => Structure::Terminal(StructureTerminal(reference)),
-            StructureType::Tower => Structure::Tower(StructureTower(reference)),
-            StructureType::Wall => Structure::Wall(StructureWall(reference)),
-        }
-    }
-}
-
-impl TryFrom<Value> for Structure {
-    type Error = ConversionError;
-
-    fn try_from(v: Value) -> Result<Structure, Self::Error> {
-        Ok(Self::from_reference(v.try_into()?))
-    }
-}
 
 /// See [`IntoExpectedType`]
 pub trait FromExpectedType<T>: Sized {
@@ -364,7 +231,9 @@ pub unsafe trait StructureProperties: RoomObjectProperties {
         js_unwrap!(@{self.as_ref()}.notifyWhenAttacked(@{notify_when_attacked}))
     }
     fn as_structure(self) -> Structure {
-        Structure::from_reference(self.into())
+        Into::<Reference>::into(self)
+            .into_expected_type()
+            .expect("expected converting a StructureProperties to a Structure would suceed.")
     }
 }
 

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -288,7 +288,7 @@ where
     T: RoomObjectProperties,
 {
     fn pos(&self) -> RoomPosition {
-        js_unwrap!(@{self.as_ref()}.pos)
+        js_unwrap_ref!(@{self.as_ref()}.pos)
     }
 }
 
@@ -303,7 +303,7 @@ pub unsafe trait RoomObjectProperties:
     AsRef<Reference> + Into<Reference> + HasPosition
 {
     fn room(&self) -> Room {
-        js_unwrap!(@{self.as_ref()}.room)
+        js_unwrap_ref!(@{self.as_ref()}.room)
     }
 }
 

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -15,7 +15,7 @@
 use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::{Reference, ReferenceType, Value};
 
-use {ResourceType, ReturnCode, StructureType, ConversionError};
+use {ConversionError, IntoExpectedType, ResourceType, ReturnCode, StructureType};
 
 mod impls;
 mod structure;
@@ -99,73 +99,6 @@ reference_wrappers!(
     #[reference(instance_of = "Tombstone")]
     Tombstone,
 );
-
-/// See [`IntoExpectedType`]
-pub trait FromExpectedType<T>: Sized {
-    fn from_expected_type(v: T) -> Result<Self, ConversionError>;
-}
-
-/// Trait for casting api results which we expect to be the right thing as long as all JS code is
-/// behaving as expected.
-///
-/// This trait allows us to switch between checked and unchecked casts at compile time with the
-/// `"check-all-casts"` feature flag.
-pub trait IntoExpectedType<T> {
-    /// Casts this value as the target type, making the assumption that the types are correct.
-    ///
-    /// # Error conditions
-    ///
-    /// If the types don't match up, and `"check-all-casts"` is enabled, this will return an error.
-    ///
-    /// If this is a non-`Reference` `Value`, this will return an error.
-    fn into_expected_type(self) -> Result<T, ConversionError>;
-}
-
-impl<T> FromExpectedType<Value> for T
-where
-    T: FromExpectedType<Reference>,
-{
-    fn from_expected_type(v: Value) -> Result<Self, ConversionError> {
-        Reference::try_from(v).and_then(|reference| reference.into_expected_type())
-    }
-}
-
-impl<T> FromExpectedType<Value> for Option<T>
-where
-    T: FromExpectedType<Reference>,
-{
-    fn from_expected_type(v: Value) -> Result<Self, ConversionError> {
-        <Option<Reference>>::try_from(v).and_then(|opt_reference| {
-            opt_reference
-                .map(|reference| reference.into_expected_type().map(Some))
-                .unwrap_or(Ok(None))
-        })
-    }
-}
-
-// TODO: this is inefficient
-impl<T> FromExpectedType<Value> for Vec<T>
-where
-    T: FromExpectedType<Reference>,
-{
-    fn from_expected_type(v: Value) -> Result<Self, ConversionError> {
-        <Vec<Reference>>::try_from(v).and_then(|ref_vec| {
-            ref_vec
-                .into_iter()
-                .map(|reference| reference.into_expected_type())
-                .collect()
-        })
-    }
-}
-
-impl<T, U> IntoExpectedType<U> for T
-where
-    U: FromExpectedType<T>,
-{
-    fn into_expected_type(self) -> Result<U, ConversionError> {
-        U::from_expected_type(self)
-    }
-}
 
 /// Trait for things which have positions in the Screeps world.
 ///

--- a/screeps-game-api/src/objects/structure.rs
+++ b/screeps-game-api/src/objects/structure.rs
@@ -1,0 +1,89 @@
+use stdweb::unstable::{TryFrom, TryInto};
+use stdweb::{InstanceOf, Reference, ReferenceType, Value};
+
+use {ConversionError, StructureType};
+
+use super::*;
+
+pub enum Structure {
+    Container(StructureContainer),
+    Controller(StructureController),
+    Extension(StructureExtension),
+    Extractor(StructureExtractor),
+    KeeperLair(StructureKeeperLair),
+    Lab(StructureLab),
+    Link(StructureLink),
+    Nuker(StructureNuker),
+    Observer(StructureObserver),
+    PowerBank(StructurePowerBank),
+    PowerSpawn(StructurePowerSpawn),
+    Portal(StructurePortal),
+    Rampart(StructureRampart),
+    Road(StructureRoad),
+    Spawn(StructureSpawn),
+    Storage(StructureStorage),
+    Terminal(StructureTerminal),
+    Tower(StructureTower),
+    Wall(StructureWall),
+}
+
+impl AsRef<Reference> for Structure {
+    fn as_ref(&self) -> &Reference {
+        match_structure_variants!(self, v => v.as_ref())
+    }
+}
+impl From<Structure> for Reference {
+    fn from(wrapper: Structure) -> Reference {
+        match_structure_variants!(wrapper, v => v.0)
+    }
+}
+
+impl FromExpectedType<Reference> for Structure {
+    fn from_expected_type(reference: Reference) -> Result<Self, ConversionError> {
+        let structure_type = js!(return @{&reference}.structureType;).try_into()?;
+
+        let structure = construct_structure_variants!(
+            structure_type => reference.into_expected_type()?
+        );
+
+        Ok(structure)
+    }
+}
+
+impl TryFrom<Reference> for Structure {
+    type Error = ConversionError;
+
+    fn try_from(reference: Reference) -> Result<Self, ConversionError> {
+        let structure_type = js!(return @{&reference}.structureType;).try_into()?;
+
+        let structure = construct_structure_variants!(
+            structure_type => reference.try_into()?
+        );
+
+        Ok(structure)
+    }
+}
+
+impl InstanceOf for Structure {
+    fn instance_of(reference: &Reference) -> bool {
+        js_unwrap!(@{reference} instanceof Structure)
+    }
+}
+
+impl TryFrom<Value> for Structure {
+    type Error = ConversionError;
+
+    fn try_from(v: Value) -> Result<Structure, Self::Error> {
+        Reference::try_from(v).and_then(Self::try_from)
+    }
+}
+
+impl ReferenceType for Structure {
+    unsafe fn from_reference_unchecked(reference: Reference) -> Self {
+        let structure_type = js_unwrap!(@{&reference}.structureType);
+
+        construct_structure_variants!(
+            structure_type => ReferenceType::from_reference_unchecked(reference)
+        )
+    }
+}

--- a/screeps-game-api/src/objects/structure.rs
+++ b/screeps-game-api/src/objects/structure.rs
@@ -1,7 +1,7 @@
 use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::{InstanceOf, Reference, ReferenceType, Value};
 
-use {ConversionError, StructureType};
+use {ConversionError, StructureType, FromExpectedType};
 
 use super::*;
 

--- a/screeps-game-api/src/objects/structure.rs
+++ b/screeps-game-api/src/objects/structure.rs
@@ -32,6 +32,7 @@ impl AsRef<Reference> for Structure {
         match_structure_variants!(self, v => v.as_ref())
     }
 }
+
 impl From<Structure> for Reference {
     fn from(wrapper: Structure) -> Reference {
         match_structure_variants!(wrapper, v => v.0)

--- a/screeps-game-api/src/objects/structure.rs
+++ b/screeps-game-api/src/objects/structure.rs
@@ -1,7 +1,7 @@
-use stdweb::unstable::{TryFrom, TryInto};
 use stdweb::{InstanceOf, Reference, ReferenceType, Value};
 
-use {ConversionError, StructureType, FromExpectedType};
+use traits::{TryFrom, TryInto};
+use {ConversionError, FromExpectedType, StructureType};
 
 use super::*;
 

--- a/screeps-game-api/src/pathfinder.rs
+++ b/screeps-game-api/src/pathfinder.rs
@@ -2,9 +2,9 @@ use std::marker::PhantomData;
 
 use std::{f64, mem};
 
-use stdweb::{unstable::TryInto, web::TypedArray, Array, Object, Reference, UnsafeTypedArray};
+use stdweb::{web::TypedArray, Array, Object, Reference, UnsafeTypedArray};
 
-use {HasPosition, LocalRoomPosition, RoomPosition};
+use {traits::TryInto, HasPosition, LocalRoomPosition, RoomPosition};
 
 #[derive(Clone, Debug)]
 pub struct LocalCostMatrix {

--- a/screeps-game-api/src/positions.rs
+++ b/screeps-game-api/src/positions.rs
@@ -266,9 +266,9 @@ impl HasPosition for LocalRoomPosition {
 }
 
 mod stdweb {
-    use stdweb::unstable::{TryFrom, TryInto};
-
     use stdweb::Value;
+
+    use traits::{TryFrom, TryInto};
 
     use super::{LocalRoomName, LocalRoomPosition};
 

--- a/screeps-game-api/src/traits.rs
+++ b/screeps-game-api/src/traits.rs
@@ -1,0 +1,72 @@
+//! Useful traits for interacting with JavaScript above what [`stdweb`] provides.
+use stdweb::unstable::TryFrom;
+use stdweb::{Reference, Value};
+
+use ConversionError;
+
+/// See [`IntoExpectedType`]
+pub trait FromExpectedType<T>: Sized {
+    fn from_expected_type(v: T) -> Result<Self, ConversionError>;
+}
+
+/// Trait for casting api results which we expect to be the right thing as long as all JS code is
+/// behaving as expected.
+///
+/// This trait allows us to switch between checked and unchecked casts at compile time with the
+/// `"check-all-casts"` feature flag.
+pub trait IntoExpectedType<T> {
+    /// Casts this value as the target type, making the assumption that the types are correct.
+    ///
+    /// # Error conditions
+    ///
+    /// If the types don't match up, and `"check-all-casts"` is enabled, this will return an error.
+    ///
+    /// If this is a non-`Reference` `Value`, this will return an error.
+    fn into_expected_type(self) -> Result<T, ConversionError>;
+}
+
+impl<T> FromExpectedType<Value> for T
+where
+    T: FromExpectedType<Reference>,
+{
+    fn from_expected_type(v: Value) -> Result<Self, ConversionError> {
+        Reference::try_from(v).and_then(|reference| reference.into_expected_type())
+    }
+}
+
+impl<T> FromExpectedType<Value> for Option<T>
+where
+    T: FromExpectedType<Reference>,
+{
+    fn from_expected_type(v: Value) -> Result<Self, ConversionError> {
+        <Option<Reference>>::try_from(v).and_then(|opt_reference| {
+            opt_reference
+                .map(|reference| reference.into_expected_type().map(Some))
+                .unwrap_or(Ok(None))
+        })
+    }
+}
+
+// TODO: this is inefficient
+impl<T> FromExpectedType<Value> for Vec<T>
+where
+    T: FromExpectedType<Reference>,
+{
+    fn from_expected_type(v: Value) -> Result<Self, ConversionError> {
+        <Vec<Reference>>::try_from(v).and_then(|ref_vec| {
+            ref_vec
+                .into_iter()
+                .map(|reference| reference.into_expected_type())
+                .collect()
+        })
+    }
+}
+
+impl<T, U> IntoExpectedType<U> for T
+where
+    U: FromExpectedType<T>,
+{
+    fn into_expected_type(self) -> Result<U, ConversionError> {
+        U::from_expected_type(self)
+    }
+}

--- a/screeps-game-api/src/traits.rs
+++ b/screeps-game-api/src/traits.rs
@@ -1,8 +1,9 @@
 //! Useful traits for interacting with JavaScript above what [`stdweb`] provides.
-use stdweb::unstable::TryFrom;
 use stdweb::{Reference, Value};
 
 use ConversionError;
+
+pub use stdweb::unstable::{TryFrom, TryInto};
 
 /// See [`IntoExpectedType`]
 pub trait FromExpectedType<T>: Sized {


### PR DESCRIPTION
Should be pretty complete now.

Includes renaming `get_object` into `get_object_erased` and adding `get_object_typed` for attempting a cast before returning.