### PR TITLE
Use a new 'use' style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ We adhere to the following guidelines:
 - Code Formatting: [fmt-rfcs Rust Style Guide]
 - API building: [Rust API Guidelines]
 
-# Code Formatting
+In addition, we have the following in-house guidelines:
+
+## Code Formatting
 
 Please run `rustfmt` on the files you edit when submitting to this repository. This will handle all
 style issues mentioned in the 'fmt-rfcs' guidelines, so you should be able to simply run `cargo fmt`
@@ -30,6 +32,58 @@ Then to format the code in this repository, use the following:
 $ cargo fmt
 ```
 
+## `use` formatting
+
+`use` statements should be at the top of the file, module or function they are used within.
+Importing at the module level should be prefered to importing within functions, with the
+exception of importing enum variants (`use self::MyEnum::*;` is useful when dealing with
+big enums, but it's best kept only within the function it's used in).
+
+When importing multiple things, `use` statements should be separated into the following
+newline-separated groups:
+
+- imports from `std`
+- imports from external crates
+- imports from the crate root
+- imports from `self` or `super`.
+
+In addition, all imports should use the use [RFC 2128] "nested groups" style. All imports inside
+each of the groups and for each external crate should be grouped under one `use` statement.
+
+
+Exampe import section:
+
+```rust
+use std::{
+    borrow::Cow,
+    cmp::{Eq, PartialEq},
+    collections::HashMap,
+    error, f64, fmt,
+    marker::PhantomData,
+    ops,
+};
+
+use serde::de::{Deserialize, Deserializer, Error, Unexpected, Visitor};
+use stdweb::{
+    unstable::{TryFrom, TryInto},
+    Reference, Value,
+};
+
+
+use {
+    constants::{ResourceType, ReturnCode, StructureType},
+    ConversionError,
+};
+```
+
+Last, when importing from within the current crate, try to import from a more specific module rather
+than a less specific one. When the crate re-exports tons of types from inner modules, it can be
+tempting to just import everything from the crate root, but this makes it all more confusing. Import
+from a more specific module which defines the type rather than having
+`use {ResourceType, StructureProperties, LocalRoomPosition};` with each type coming from a different
+module.
+
 [screeps slack]: https://chat.screeps.com/
 [fmt-rfcs Rust Style Guide]: https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md
 [Rust API Guidelines]: https://rust-lang-nursery.github.io/api-guidelines/
+[RFC 2128]: https://github.com/rust-lang/rfcs/blob/master/text/2128-use-nested-groups.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,23 @@ Then to format the code in this repository, use the following:
 $ cargo fmt
 ```
 
+## Ordering within a module
+
+Items within a module should be order as follows. Each separate group should be newline separated
+with the exception of module documentation. The group immediately following module documentation
+should be directly under it with no double-newline separating it.
+
+- `//!` module documentation
+- `extern crate` declarations
+- private `use` declarations
+- `mod` declarations
+- `pub use` declarations
+- all other [items] in no particular order
+
 ## `use` formatting
 
-Private `use` statements should be above all other non-use items within the module or function they
-are declared.
+Private `use` statements should all be together: there should be no non-private-`use` statements
+between two private `use` statements.
 
 Importing at the module level should be preferred to importing within functions, with the
 exception of importing enum variants. Any statement like `use self::MyEnum::*;` should be used only
@@ -47,13 +60,15 @@ newline-separated groups:
 - imports from `std`
 - imports from external crates
 - imports from the crate root
-- imports from `self` or `super`.
+- imports from `super::`
+- imports from `self::`
 
-`pub use` statements should all be in one group under any `mod` statements in a file.
+`pub use` statements should be similarly grouped, but should be separate from private `use` as
+mentioned in [Ordering within a module].
 
-All imports should use the use [RFC 2128] "nested groups" style. There should be one top-level
-`use` statement for each of `std`, the current root, `self`, `super` and one for each external
-crate.
+All imports within a newline-separated group should use the use [RFC 2128] "nested groups" style.
+There should be one top-level `use` statement for each of `std`, the crate root, `self`, `super`
+and one for each external crate.
 
 In accordance to the `fmt-rfcs`, top-level `use` statements within a group and items within a `use`
 statement should be alphabetically ordered.
@@ -76,7 +91,6 @@ use stdweb::{
     Reference, Value,
 };
 use void::Void;
-
 
 use {
     constants::{ResourceType, ReturnCode, StructureType},
@@ -101,3 +115,4 @@ but if in `constants`, then it can just be done with `objects::Step`.
 [fmt-rfcs Rust Style Guide]: https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md
 [Rust API Guidelines]: https://rust-lang-nursery.github.io/api-guidelines/
 [RFC 2128]: https://github.com/rust-lang/rfcs/blob/master/text/2128-use-nested-groups.md
+[items]: https://doc.rust-lang.org/reference/items.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,13 @@ than a less specific one. When the crate re-exports tons of types from inner mod
 tempting to just import everything from the crate root, but this makes it all more confusing. Import
 from a more specific module which defines the type rather than having
 `use {ResourceType, StructureProperties, LocalRoomPosition};` with each type coming from a different
-module.
+module. Things should at minimum use the top-level module, but can also use more specific imports
+for things from within the same top-level module.
+
+To clarify, each import from within the same crate should be qualified by one level of module
+outside of the current module's hierarchy. If in `objects::impl::construction_site`, importing
+`objects::impl::room::Step` should be done with `objects::impl::room::Step` or `super::room::Step`,
+but if in `constants`, then it can just be done with `objects::Step`.
 
 [screeps slack]: https://chat.screeps.com/
 [fmt-rfcs Rust Style Guide]: https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,12 @@ $ cargo fmt
 
 ## `use` formatting
 
-`use` statements should be at the top of the file, module or function they are used within.
-Importing at the module level should be prefered to importing within functions, with the
-exception of importing enum variants (`use self::MyEnum::*;` is useful when dealing with
-big enums, but it's best kept only within the function it's used in).
+Private `use` statements should be above all other non-use items within the module or function they
+are declared.
+
+Importing at the module level should be preferred to importing within functions, with the
+exception of importing enum variants. Any statement like `use self::MyEnum::*;` should be used only
+within a function in order to avoid polluting the module namespace.
 
 When importing multiple things, `use` statements should be separated into the following
 newline-separated groups:
@@ -47,11 +49,16 @@ newline-separated groups:
 - imports from the crate root
 - imports from `self` or `super`.
 
-In addition, all imports should use the use [RFC 2128] "nested groups" style. All imports inside
-each of the groups and for each external crate should be grouped under one `use` statement.
+`pub use` statements should all be in one group under any `mod` statements in a file.
 
+All imports should use the use [RFC 2128] "nested groups" style. There should be one top-level
+`use` statement for each of `std`, the current root, `self`, `super` and one for each external
+crate.
 
-Exampe import section:
+In accordance to the `fmt-rfcs`, top-level `use` statements within a group and items within a `use`
+statement should be alphabetically ordered.
+
+Example import section:
 
 ```rust
 use std::{
@@ -68,6 +75,7 @@ use stdweb::{
     unstable::{TryFrom, TryInto},
     Reference, Value,
 };
+use void::Void;
 
 
 use {

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -103,13 +103,14 @@ unsafe impl FindConstant for FindObject {
 }
 
 pub mod find {
-    use super::FindConstant;
     use stdweb::unstable::TryFrom;
 
     use objects::{
         ConstructionSite, Creep, Flag, Mineral, Nuke, OwnedStructure, Resource, RoomPosition,
         Source, Structure, StructureSpawn, Tombstone,
     };
+
+    use super::FindConstant;
 
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Exit(i32);
@@ -321,12 +322,13 @@ pub unsafe trait LookConstant {
 
 pub mod look {
     use {
+        objects::{
+            ConstructionSite, Creep, Flag, Mineral, Nuke, Resource, Source, Structure, Tombstone,
+        },
         traits::{IntoExpectedType, TryInto},
-        ConstructionSite, Creep, Flag, Mineral, Nuke, Resource, Source, Structure, Terrain,
-        Tombstone,
     };
 
-    use super::{Look, LookConstant};
+    use super::{Look, LookConstant, Terrain};
 
     typesafe_look_constants! {
         CREEPS, Look::Creeps, Creep, IntoExpectedType::into_expected_type;

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -126,9 +126,11 @@ pub mod gcl {
 pub mod map {
     use std::collections;
 
-    use constants::{find::Exit, ReturnCode};
-    use traits::{TryFrom, TryInto};
-    use {Direction, Room, RoomPosition, Terrain};
+    use {
+        constants::{find::Exit, Direction, ReturnCode, Terrain},
+        objects::{Room, RoomPosition},
+        traits::{TryFrom, TryInto},
+    };
 
     /// See [http://docs.screeps.com/api/#Game.map.describeExits]
     ///

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -1,5 +1,8 @@
-use traits::TryInto;
-use {ConversionError, RoomObject, RoomObjectProperties};
+use {
+    objects::{RoomObject, RoomObjectProperties},
+    traits::TryInto,
+    ConversionError,
+};
 
 // TODO: split these out into separate files once we add documentation.
 //

--- a/screeps-game-api/src/lib.rs
+++ b/screeps-game-api/src/lib.rs
@@ -45,10 +45,12 @@ mod positions;
 pub mod raw_memory;
 pub mod traits;
 
-pub use constants::*;
-pub use objects::*;
-pub use positions::{LocalRoomName, LocalRoomPosition};
-pub use traits::{FromExpectedType, IntoExpectedType};
+pub use {
+    constants::*,
+    objects::*,
+    positions::{LocalRoomName, LocalRoomPosition},
+    traits::{FromExpectedType, IntoExpectedType},
+};
 
 pub(crate) use stdweb::private::ConversionError;
 

--- a/screeps-game-api/src/memory.rs
+++ b/screeps-game-api/src/memory.rs
@@ -50,8 +50,8 @@
 //! from those objects will also result in a `MemoryReference` which instead
 //! points at the root of this object's memory.
 //!
-
 use std::fmt;
+
 use stdweb::{JsSerialize, Reference, Value};
 
 use {

--- a/screeps-game-api/src/objects/impls/construction_site.rs
+++ b/screeps-game-api/src/objects/impls/construction_site.rs
@@ -1,7 +1,8 @@
-use {traits::TryInto, ReturnCode, StructureType};
-
-// TODO: Use root import after https://github.com/rust-lang/rust/issues/53140 is fixed.
-use super::super::ConstructionSite;
+use {
+    constants::{ReturnCode, StructureType},
+    objects::ConstructionSite,
+    traits::TryInto,
+};
 
 simple_accessors! {
     ConstructionSite;

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -2,11 +2,13 @@ use {
     constants::{Direction, Part, ResourceType, ReturnCode},
     memory::MemoryReference,
     objects::{
-        Attackable, ConstructionSite, Creep, HasPosition, Resource, Source, Step,
-        StructureController, StructureProperties, Transferable, Withdrawable,
+        Attackable, ConstructionSite, Creep, HasPosition, Resource, Source, StructureController,
+        StructureProperties, Transferable, Withdrawable,
     },
     pathfinder::SearchResults,
 };
+
+use super::room::Step;
 
 impl Creep {
     pub fn carry_total(&self) -> i32 {

--- a/screeps-game-api/src/objects/impls/flag.rs
+++ b/screeps-game-api/src/objects/impls/flag.rs
@@ -1,4 +1,7 @@
-use {constants::Color, Flag, HasPosition};
+use {
+    constants::Color,
+    objects::{Flag, HasPosition},
+};
 
 simple_accessors! {
     Flag;

--- a/screeps-game-api/src/objects/impls/mineral.rs
+++ b/screeps-game-api/src/objects/impls/mineral.rs
@@ -1,6 +1,6 @@
 use {
     constants::{Density, ResourceType},
-    Mineral,
+    objects::Mineral,
 };
 
 simple_accessors! {

--- a/screeps-game-api/src/objects/impls/nuke.rs
+++ b/screeps-game-api/src/objects/impls/nuke.rs
@@ -1,4 +1,4 @@
-use Nuke;
+use objects::Nuke;
 
 simple_accessors! {
     Nuke;

--- a/screeps-game-api/src/objects/impls/resource.rs
+++ b/screeps-game-api/src/objects/impls/resource.rs
@@ -1,5 +1,4 @@
-use constants::ResourceType;
-use objects::Resource;
+use {constants::ResourceType, objects::Resource};
 
 impl Resource {
     pub fn resource_type(&self) -> ResourceType {

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -2,16 +2,18 @@ use std::{marker::PhantomData, mem, ops::Range};
 
 use stdweb::Reference;
 
-use constants::{
-    find::Exit, Color, Direction, FindConstant, LookConstant, ReturnCode, StructureType,
+use {
+    constants::{
+        find::Exit, Color, Direction, FindConstant, LookConstant, ReturnCode, StructureType,
+    },
+    memory::MemoryReference,
+    objects::{
+        HasPosition, Room, RoomPosition, StructureController, StructureStorage, StructureTerminal,
+    },
+    pathfinder::CostMatrix,
+    positions::LocalRoomName,
+    traits::TryInto,
 };
-use memory::MemoryReference;
-use objects::{
-    HasPosition, Room, RoomPosition, StructureController, StructureStorage, StructureTerminal,
-};
-use pathfinder::CostMatrix;
-use positions::LocalRoomName;
-use traits::TryInto;
 
 simple_accessors! {
     Room;

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -3,11 +3,13 @@ use std::cmp::{Eq, PartialEq};
 use {
     constants::{Color, Direction, FindConstant, LookConstant, ReturnCode},
     game,
-    objects::{FindOptions, HasPosition, Path, RoomPosition, StructureType},
+    objects::{HasPosition, RoomPosition, StructureType},
     pathfinder::CostMatrix,
     positions::LocalRoomPosition,
     traits::TryInto,
 };
+
+use super::room::{FindOptions, Path};
 
 impl RoomPosition {
     pub fn new(x: u8, y: u8, room_name: &str) -> Self {

--- a/screeps-game-api/src/objects/impls/structure_controller.rs
+++ b/screeps-game-api/src/objects/impls/structure_controller.rs
@@ -1,7 +1,6 @@
 use stdweb::Value;
 
-use constants::ReturnCode;
-use objects::StructureController;
+use {constants::ReturnCode, objects::StructureController};
 
 simple_accessors! {
     StructureController;

--- a/screeps-game-api/src/objects/impls/structure_keeper_lair.rs
+++ b/screeps-game-api/src/objects/impls/structure_keeper_lair.rs
@@ -1,4 +1,4 @@
-use StructureKeeperLair;
+use objects::StructureKeeperLair;
 
 simple_accessors! {
     StructureKeeperLair;

--- a/screeps-game-api/src/objects/impls/structure_lab.rs
+++ b/screeps-game-api/src/objects/impls/structure_lab.rs
@@ -1,6 +1,6 @@
 use {
     constants::{ResourceType, ReturnCode},
-    {Creep, StructureLab},
+    objects::{Creep, StructureLab},
 };
 
 simple_accessors! {

--- a/screeps-game-api/src/objects/impls/structure_link.rs
+++ b/screeps-game-api/src/objects/impls/structure_link.rs
@@ -1,4 +1,4 @@
-use {constants::ReturnCode, StructureLink};
+use {constants::ReturnCode, objects::StructureLink};
 
 impl StructureLink {
     pub fn transfer_energy(&self, target: &StructureLink, amount: Option<u32>) -> ReturnCode {

--- a/screeps-game-api/src/objects/impls/structure_nuker.rs
+++ b/screeps-game-api/src/objects/impls/structure_nuker.rs
@@ -1,6 +1,6 @@
 use {
     constants::ReturnCode,
-    {RoomPosition, StructureNuker},
+    objects::{RoomPosition, StructureNuker},
 };
 
 simple_accessors! {

--- a/screeps-game-api/src/objects/impls/structure_observer.rs
+++ b/screeps-game-api/src/objects/impls/structure_observer.rs
@@ -1,4 +1,4 @@
-use {constants::ReturnCode, StructureObserver};
+use {constants::ReturnCode, objects::StructureObserver};
 
 impl StructureObserver {
     pub fn observe_room(&self, room_name: &str) -> ReturnCode {

--- a/screeps-game-api/src/objects/impls/structure_portal.rs
+++ b/screeps-game-api/src/objects/impls/structure_portal.rs
@@ -1,6 +1,6 @@
 use {
+    objects::{RoomPosition, StructurePortal},
     traits::TryInto,
-    {RoomPosition, StructurePortal},
 };
 
 #[derive(Deserialize, Debug)]

--- a/screeps-game-api/src/objects/impls/structure_power_bank.rs
+++ b/screeps-game-api/src/objects/impls/structure_power_bank.rs
@@ -1,4 +1,4 @@
-use StructurePowerBank;
+use objects::StructurePowerBank;
 
 simple_accessors! {
     StructurePowerBank;

--- a/screeps-game-api/src/objects/impls/structure_power_spawn.rs
+++ b/screeps-game-api/src/objects/impls/structure_power_spawn.rs
@@ -1,4 +1,4 @@
-use {constants::ReturnCode, StructurePowerSpawn};
+use {constants::ReturnCode, objects::StructurePowerSpawn};
 
 simple_accessors! {
     StructurePowerSpawn;

--- a/screeps-game-api/src/objects/impls/structure_rampart.rs
+++ b/screeps-game-api/src/objects/impls/structure_rampart.rs
@@ -1,4 +1,4 @@
-use {constants::ReturnCode, StructureRampart};
+use {constants::ReturnCode, objects::StructureRampart};
 
 simple_accessors!{
     StructureRampart;

--- a/screeps-game-api/src/objects/impls/structure_spawn.rs
+++ b/screeps-game-api/src/objects/impls/structure_spawn.rs
@@ -1,10 +1,11 @@
 use stdweb::Reference;
 
-use memory::MemoryReference;
-use objects::StructureSpawn;
-use traits::TryInto;
-
-use {Creep, Direction, Part, ReturnCode, StructureProperties};
+use {
+    constants::{Direction, Part, ReturnCode},
+    memory::MemoryReference,
+    objects::{Creep, StructureProperties, StructureSpawn},
+    traits::TryInto,
+};
 
 simple_accessors! {
     StructureSpawn;

--- a/screeps-game-api/src/objects/impls/structure_terminal.rs
+++ b/screeps-game-api/src/objects/impls/structure_terminal.rs
@@ -1,6 +1,6 @@
 use {
     constants::{ResourceType, ReturnCode},
-    StructureTerminal,
+    objects::StructureTerminal,
 };
 
 impl StructureTerminal {

--- a/screeps-game-api/src/objects/impls/structure_tower.rs
+++ b/screeps-game-api/src/objects/impls/structure_tower.rs
@@ -1,6 +1,6 @@
 use {
     constants::ReturnCode,
-    {Creep, Structure, StructureTower},
+    objects::{Creep, Structure, StructureTower},
 };
 
 impl StructureTower {

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -14,8 +14,11 @@
 //! unexpected things into dictionaries which we trust.
 use stdweb::{Reference, ReferenceType, Value};
 
-use traits::{TryFrom, TryInto};
-use {ConversionError, IntoExpectedType, ResourceType, ReturnCode, StructureType};
+use {
+    constants::{ResourceType, ReturnCode, StructureType},
+    traits::{IntoExpectedType, TryFrom, TryInto},
+    ConversionError,
+};
 
 mod impls;
 mod structure;

--- a/screeps-game-api/src/objects/structure.rs
+++ b/screeps-game-api/src/objects/structure.rs
@@ -1,7 +1,10 @@
 use stdweb::{InstanceOf, Reference, ReferenceType, Value};
 
-use traits::{TryFrom, TryInto};
-use {ConversionError, FromExpectedType, StructureType};
+use {
+    constants::StructureType,
+    traits::{FromExpectedType, IntoExpectedType, TryFrom, TryInto},
+    ConversionError,
+};
 
 use super::*;
 

--- a/screeps-game-api/src/pathfinder.rs
+++ b/screeps-game-api/src/pathfinder.rs
@@ -1,10 +1,12 @@
-use std::marker::PhantomData;
-
-use std::{f64, mem};
+use std::{f64, marker::PhantomData, mem};
 
 use stdweb::{web::TypedArray, Array, Object, Reference, UnsafeTypedArray};
 
-use {traits::TryInto, HasPosition, LocalRoomPosition, RoomPosition};
+use {
+    objects::{HasPosition, RoomPosition},
+    positions::LocalRoomPosition,
+    traits::TryInto,
+};
 
 #[derive(Clone, Debug)]
 pub struct LocalCostMatrix {

--- a/screeps-game-api/src/positions.rs
+++ b/screeps-game-api/src/positions.rs
@@ -1,7 +1,6 @@
 //! Structures relating to room name parsing.
 
-use std::borrow::Cow;
-use std::{error, fmt, ops};
+use std::{borrow::Cow, error, fmt, ops};
 
 use objects::{HasPosition, RoomPosition};
 


### PR DESCRIPTION
This normalizes all `use` to a slightly different style that I've grown to like in other projects.

This also updates CONTRIBUTING.md (from #48) to include the logic of this use group style.

I mostly like this style because it groups uses together and creates no ambiguity as to how things should be formatted. There's always one `use` statement per top-level item, so there's never any decision that needs to be made about what imports to group together and what imports not to group together.

CC @ASalvail: see what you think of this.

I don't think it's a big thing, but it does affect all the code. I don't feel too strongly about this particular style, but I would like to normalize to something.