### PR TITLE
findRoute and findExit callback implementations

### DIFF
--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -120,7 +120,7 @@ pub mod find {
 
     use super::FindConstant;
 
-    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
     pub struct Exit(i32);
 
     impl Exit {

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -121,6 +121,7 @@ pub mod find {
     use super::FindConstant;
 
     #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
+    #[serde(transparent)]
     pub struct Exit(i32);
 
     impl Exit {

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -357,7 +357,10 @@ pub mod look {
 #[repr(u32)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "constants-serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "constants-serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(
+    feature = "constants-serde",
+    serde(rename_all = "snake_case")
+)]
 pub enum Part {
     Move = 0,
     Work = 1,

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -187,15 +187,38 @@ pub mod map {
     /// Implements `Game.map.findExit`.
     ///
     /// Does not yet support callbacks.
-    pub fn find_exit(from_room: Room, to_room: Room) -> Result<Exit, ReturnCode> {
-        let code: i32 = js_unwrap!{Game.map.findExit(@{from_room.name()}, @{to_room.name()})};
+    pub fn find_exit(from_room: &Room, to_room: &Room) -> Result<Exit, ReturnCode> {
+        let code: i32 = js_unwrap!{Game.map.findExit(@{from_room.as_ref()}, @{to_room.as_ref()})};
         Exit::try_from(code)
             .map_err(|v| v.try_into().expect("find_exit: Error code not recognized."))
     }
 
+    pub fn find_exit_callback(from_room: &Room, to_room: &Room, route_callback: impl Fn(String, String) -> f64) -> Result<Exit, ReturnCode> {
+        // Actual callback
+        fn callback(room_name: String, from_room_name: String) -> f64 {
+            FR_CALLBACK.with(|callback| callback(room_name, from_room_name))
+        }
+
+        let callback_type_erased: Box<Fn(String, String) -> f64> = Box::new(route_callback);
+
+        let callback_lifetime_erased: Box<Fn(String, String) -> f64 + 'static> =
+        unsafe { mem::transmute(callback_type_erased) };
+
+        FR_CALLBACK.set(&callback_lifetime_erased, || {
+            let code: i32 = js_unwrap!{Game.map.findExit(@{from_room.as_ref()}, @{to_room.as_ref()}, @{callback})};
+            Exit::try_from(code)
+            .map_err(|v| v.try_into().expect("find_exit: Error code not recognized."))
+        })
+    }
+
+    pub fn find_route(from_room: &Room, to_room: &Room) -> Result<Vec<ExitDirection>, ReturnCode> {
+        let v = js!(return Game.map.findRoute(@{from_room.as_ref()}, @{to_room.as_ref()}););
+        parse_find_route_returned_value(v)
+    }
+
     scoped_thread_local!(static FR_CALLBACK: Box<(Fn(String, String) -> f64)>);
 
-    pub fn find_route_callback(from_room: Room, to_room: Room, route_callback: impl Fn(String, String) -> f64) -> Result<Vec<ExitDirection>, ReturnCode> {
+    pub fn find_route_callback(from_room: &Room, to_room: &Room, route_callback: impl Fn(String, String) -> f64) -> Result<Vec<ExitDirection>, ReturnCode> {
         // Actual callback
         fn callback(room_name: String, from_room_name: String) -> f64 {
             FR_CALLBACK.with(|callback| callback(room_name, from_room_name))
@@ -208,16 +231,19 @@ pub mod map {
 
         FR_CALLBACK.set(&callback_lifetime_erased, || {
             let v = js!(return Game.map.findRoute(@{from_room.as_ref()}, @{to_room.as_ref()}, @{callback}););
-
-            match v {
-                Value::Number(x) => {
-                    let i: i32 = x.try_into().unwrap();
-                    Err(i.try_into().expect("Unexpected return code."))
-                },
-                Value::Reference(_) => Ok(v.try_into().expect("Error on parsing exit directions.")),
-                _ => panic!("Game.map.findRoute returned an unexpected Value variant.")
-            }
+            parse_find_route_returned_value(v)
         })
+    }
+
+    fn parse_find_route_returned_value(v: Value) -> Result<Vec<ExitDirection>, ReturnCode> {
+        match v {
+            Value::Number(x) => {
+                let i: i32 = x.try_into().unwrap();
+                Err(i.try_into().expect("Unexpected return code."))
+            },
+            Value::Reference(_) => Ok(v.try_into().expect("Error on parsing exit directions.")),
+            _ => panic!("Game.map.findRoute returned an unexpected Value variant.")
+        }
     }
 
     #[derive(Clone, Debug, Deserialize)]

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -185,8 +185,6 @@ pub mod map {
     }
 
     /// Implements `Game.map.findExit`.
-    ///
-    /// Does not yet support callbacks.
     pub fn find_exit(from_room: &Room, to_room: &Room) -> Result<Exit, ReturnCode> {
         let code: i32 = js_unwrap!{Game.map.findExit(@{from_room.as_ref()}, @{to_room.as_ref()})};
         Exit::try_from(code)

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -132,8 +132,8 @@ pub mod map {
     use stdweb::Value;
 
     use {
-        constants::{find::Exit, Direction, ReturnCode, Terrain},
-        objects::RoomPosition,
+        constants::{find::Exit, Direction, ReturnCode},
+        objects::RoomTerrain,
         traits::{TryFrom, TryInto},
     };
 

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -247,7 +247,7 @@ pub mod map {
                 let i: i32 = x.try_into().unwrap();
                 Err(i
                     .try_into()
-                    .expect(&format!("Unexpected return code: {:?}.", i)))
+                    .unwrap_or_else(|val| panic!("Unexpected return code: {}", val)))
             }
             Value::Reference(_) => Ok(v.try_into().expect("Error on parsing exit directions.")),
             _ => panic!(

--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -191,7 +191,11 @@ pub mod map {
             .map_err(|v| v.try_into().expect("find_exit: Error code not recognized."))
     }
 
-    pub fn find_exit_callback(from_room: &Room, to_room: &Room, route_callback: impl Fn(String, String) -> f64) -> Result<Exit, ReturnCode> {
+    pub fn find_exit_callback(
+        from_room: &Room,
+        to_room: &Room,
+        route_callback: impl Fn(String, String) -> f64,
+    ) -> Result<Exit, ReturnCode> {
         // Actual callback
         fn callback(room_name: String, from_room_name: String) -> f64 {
             FR_CALLBACK.with(|callback| callback(room_name, from_room_name))
@@ -200,7 +204,7 @@ pub mod map {
         let callback_type_erased: Box<Fn(String, String) -> f64> = Box::new(route_callback);
 
         let callback_lifetime_erased: Box<Fn(String, String) -> f64 + 'static> =
-        unsafe { mem::transmute(callback_type_erased) };
+            unsafe { mem::transmute(callback_type_erased) };
 
         FR_CALLBACK.set(&callback_lifetime_erased, || {
             let code: i32 = js_unwrap!{Game.map.findExit(@{from_room.as_ref()}, @{to_room.as_ref()}, @{callback})};
@@ -216,7 +220,11 @@ pub mod map {
 
     scoped_thread_local!(static FR_CALLBACK: Box<(Fn(String, String) -> f64)>);
 
-    pub fn find_route_callback(from_room: &Room, to_room: &Room, route_callback: impl Fn(String, String) -> f64) -> Result<Vec<ExitDirection>, ReturnCode> {
+    pub fn find_route_callback(
+        from_room: &Room,
+        to_room: &Room,
+        route_callback: impl Fn(String, String) -> f64,
+    ) -> Result<Vec<ExitDirection>, ReturnCode> {
         // Actual callback
         fn callback(room_name: String, from_room_name: String) -> f64 {
             FR_CALLBACK.with(|callback| callback(room_name, from_room_name))
@@ -225,7 +233,7 @@ pub mod map {
         let callback_type_erased: Box<Fn(String, String) -> f64> = Box::new(route_callback);
 
         let callback_lifetime_erased: Box<Fn(String, String) -> f64 + 'static> =
-        unsafe { mem::transmute(callback_type_erased) };
+            unsafe { mem::transmute(callback_type_erased) };
 
         FR_CALLBACK.set(&callback_lifetime_erased, || {
             let v = js!(return Game.map.findRoute(@{from_room.as_ref()}, @{to_room.as_ref()}, @{callback}););
@@ -238,9 +246,9 @@ pub mod map {
             Value::Number(x) => {
                 let i: i32 = x.try_into().unwrap();
                 Err(i.try_into().expect("Unexpected return code."))
-            },
+            }
             Value::Reference(_) => Ok(v.try_into().expect("Error on parsing exit directions.")),
-            _ => panic!("Game.map.findRoute returned an unexpected Value variant.")
+            _ => panic!("Game.map.findRoute returned an unexpected Value variant."),
         }
     }
 


### PR DESCRIPTION
Use the same `scoped_thread_local` container to work both callbacks.

Both functions have a regular and a `*_callback" version.

Also adds a `game::map::ExitDirection` struct to express the output of `find_route`.
