### PR TITLE
Creep.body implementation

### DIFF
--- a/screeps-game-api/javascript/utils.js
+++ b/screeps-game-api/javascript/utils.js
@@ -192,18 +192,6 @@ function __resource_type_str_to_num(str) {
     }
 }
 
-function _hasActiveBodypart(body, type) {
-    for (var i = body.length - 1; i >= 0; i--) {
-        if (body[i].hits <= 0) {
-            break;
-        }
-        if (body[i].type === type) {
-            return true;
-        }
-    }
-    return false;
-}
-
 function __order_type_str_to_num(str) {
     switch (str) {
         case ORDER_SELL: return 0;

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -113,10 +113,6 @@ impl Creep {
         js_unwrap!(@{self.as_ref()}.getActiveBodyparts(__part_str_to_num(@{ty as i32})))
     }
 
-    pub fn has_active_bodyparts(&self, ty: Part) -> i32 {
-        js_unwrap!(_hasActiveBodyparts(@{self.as_ref()}, __part_str_to_num(@{ty as i32})))
-    }
-
     pub fn move_to<T: HasPosition>(&self, target: &T) -> ReturnCode {
         let p = target.pos();
         js_unwrap!(@{self.as_ref()}.moveTo(@{&p.0}))


### PR DESCRIPTION
This one turned out to be unfun.

The method manually create a `Vec<Bodypart>` and builds the `Bodypart`s individually. This is to avoid having to serialize using strings and changing the way constants are handled already.

Also: removes "has_bodyparts" that isn't really useful given this one.