### PR TITLE
move_to_xy_options and move_to_options

### DIFF
--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -1,18 +1,15 @@
 use std::{marker::PhantomData, mem};
 
-use stdweb::{Value, Reference};
+use stdweb::Reference;
 
 use {
     constants::{Direction, Part, ResourceType, ReturnCode},
     memory::MemoryReference,
     objects::{
-        Attackable, ConstructionSite, Creep, FindOptions, HasPosition,
-        Resource, Source, StructureController, StructureProperties, Transferable, Withdrawable,
+        Attackable, ConstructionSite, Creep, FindOptions, HasPosition, Resource, Source,
+        StructureController, StructureProperties, Transferable, Withdrawable,
     },
-
     pathfinder::{CostMatrix, SearchResults},
-    traits::TryFrom,
-
 };
 
 use super::room::Step;
@@ -87,20 +84,15 @@ impl Creep {
         &self,
         x: u32,
         y: u32,
-        reuse_path: Option<u32>,
-        serialize_memory: Option<bool>,
-        no_path_finding: Option<bool>,
-        find_options: Option<FindOptions<'a, F>>,
+        move_options: MoveToOptions<'a, F>,
     ) -> ReturnCode
     where
         F: Fn(String, CostMatrix) -> Option<CostMatrix<'a>> + 'a,
     {
-        let rp = reuse_path.unwrap_or(5u32);
-        let sm = serialize_memory.unwrap_or(true);
-        let pf = no_path_finding.unwrap_or(false);
-        let fo: FindOptions<'a, F> = find_options.unwrap_or(FindOptions::default());
-
-        let FindOptions {
+        let MoveToOptions {
+            reuse_path,
+            serialize_memory,
+            no_path_finding,
             ignore_creeps,
             ignore_destructible_structures,
             cost_callback,
@@ -111,7 +103,7 @@ impl Creep {
             range,
             plain_cost,
             swamp_cost,
-        } = fo;
+        } = move_options;
 
         // This callback is the one actually passed to JavaScript.
         fn callback(room_name: String, cost_matrix: Reference) -> Option<Reference> {
@@ -154,9 +146,9 @@ impl Creep {
                     @{x},
                     @{y},
                     {
-                        reusePath: @{rp},
-                        serializeMemory: @{sm},
-                        noPathFinding: @{pf},
+                        reusePath: @{reuse_path},
+                        serializeMemory: @{serialize_memory},
+                        noPathFinding: @{no_path_finding},
                         visualizePathStyle: undefined,  // todo
                         ignoreCreeps: @{ignore_creeps},
                         ignoreDestructibleStructures: @{ignore_destructible_structures}
@@ -298,4 +290,216 @@ creep_simple_concrete_action! {
     (ranged_heal(Creep) -> rangedHeal),
     (reserve_controller(StructureController) -> reserveController),
     (upgrade_controller(StructureController) -> upgradeController),
+}
+
+pub struct MoveToOptions<'a, F>
+where
+    F: Fn(String, CostMatrix) -> Option<CostMatrix<'a>>,
+{
+    pub(crate) reuse_path: u32,
+    pub(crate) serialize_memory: bool,
+    pub(crate) no_path_finding: bool,
+    // pub(crate) visualize_path_style: PolyStyle,
+    pub(crate) ignore_creeps: bool,
+    pub(crate) ignore_destructible_structures: bool,
+    pub(crate) cost_callback: F,
+    pub(crate) max_ops: u32,
+    pub(crate) heuristic_weight: f64,
+    pub(crate) serialize: bool,
+    pub(crate) max_rooms: u32,
+    pub(crate) range: u32,
+    pub(crate) plain_cost: u8,
+    pub(crate) swamp_cost: u8,
+}
+
+impl Default for MoveToOptions<'static, fn(String, CostMatrix) -> Option<CostMatrix<'static>>> {
+    fn default() -> Self {
+        fn cost_matrix(_: String, _: CostMatrix) -> Option<CostMatrix<'static>> {
+            None
+        }
+
+        // TODO: should we fall back onto the game's default values, or is
+        // it alright to copy them here?
+        MoveToOptions {
+            reuse_path: 5,
+            serialize_memory: true,
+            no_path_finding: false,
+            // visualize_path_style: None,
+            ignore_creeps: false,
+            ignore_destructible_structures: false,
+            cost_callback: cost_matrix,
+            max_ops: 2000,
+            heuristic_weight: 1.2,
+            serialize: false,
+            max_rooms: 16,
+            range: 0,
+            plain_cost: 1,
+            swamp_cost: 5,
+        }
+    }
+}
+
+impl MoveToOptions<'static, fn(String, CostMatrix) -> Option<CostMatrix<'static>>> {
+    /// Creates default SearchOptions
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<'a, F> MoveToOptions<'a, F>
+where
+    F: Fn(String, CostMatrix) -> Option<CostMatrix<'a>>,
+{
+    /// Enables caching of the calculated path. Default: 5 ticks
+    pub fn reuse_path(mut self, n_ticks: u32) -> Self {
+        self.reuse_path = n_ticks;
+        self
+    }
+
+    /// Whether to use the short serialized form. Default: True
+    pub fn serialize_memory(mut self, serialize: bool) -> Self {
+        self.serialize_memory = serialize;
+        self
+    }
+
+    /// Return an `ERR_NOT_FOUND` if no path is already cached. Default: False
+    pub fn no_path_finding(mut self, no_finding: bool) -> Self {
+        self.no_path_finding = no_finding;
+        self
+    }
+
+    // /// Sets the style to trace the path used by this creep. See doc for default.
+    // pub fn visualize_path_style(mut self, style: ) -> Self {
+    //     self.visualize_path_style = style;
+    //     self
+    // }
+
+    /// Sets whether the algorithm considers creeps as walkable. Default: False.
+    pub fn ignore_creeps(mut self, ignore: bool) -> Self {
+        self.ignore_creeps = ignore;
+        self
+    }
+
+    /// Sets whether the algorithm considers destructible structure as
+    /// walkable. Default: False.
+    pub fn ignore_destructible_structures(mut self, ignore: bool) -> Self {
+        self.ignore_destructible_structures = ignore;
+        self
+    }
+
+    /// Sets cost callback - default `|_, _| {}`.
+    pub fn cost_callback<'b, F2>(self, cost_callback: F2) -> MoveToOptions<'b, F2>
+    where
+        F2: Fn(String, CostMatrix) -> Option<CostMatrix<'b>>,
+    {
+        let MoveToOptions {
+            reuse_path,
+            serialize_memory,
+            no_path_finding,
+            // visualize_path_style,
+            ignore_creeps,
+            ignore_destructible_structures,
+            cost_callback: _,
+            max_ops,
+            heuristic_weight,
+            serialize,
+            max_rooms,
+            range,
+            plain_cost,
+            swamp_cost,
+        } = self;
+        MoveToOptions {
+            reuse_path,
+            serialize_memory,
+            no_path_finding,
+            // visualize_path_style,
+            ignore_creeps,
+            ignore_destructible_structures,
+            cost_callback,
+            max_ops,
+            heuristic_weight,
+            serialize,
+            max_rooms,
+            range,
+            plain_cost,
+            swamp_cost,
+        }
+    }
+
+    /// Sets maximum ops - default `2000`.
+    pub fn max_ops(mut self, ops: u32) -> Self {
+        self.max_ops = ops;
+        self
+    }
+
+    /// Sets heuristic weight - default `1.2`.
+    pub fn heuristic_weight(mut self, weight: f64) -> Self {
+        self.heuristic_weight = weight;
+        self
+    }
+
+    /// Sets whether the returned path should be passed to `Room.serializePath`.
+    pub fn serialize(mut self, s: bool) -> Self {
+        self.serialize = s;
+        self
+    }
+
+    /// Sets maximum rooms - default `16`, max `16`.
+    pub fn max_rooms(mut self, rooms: u32) -> Self {
+        self.max_rooms = rooms;
+        self
+    }
+
+    pub fn range(mut self, k: u32) -> Self {
+        self.range = k;
+        self
+    }
+
+    /// Sets plain cost - default `1`.
+    pub fn plain_cost(mut self, cost: u8) -> Self {
+        self.plain_cost = cost;
+        self
+    }
+
+    /// Sets swamp cost - default `5`.
+    pub fn swamp_cost(mut self, cost: u8) -> Self {
+        self.swamp_cost = cost;
+        self
+    }
+
+    /// Sets options related to FindOptions. Defaults to FindOptions default.
+    pub fn find_options<'b, F2>(self, find_options: FindOptions<'b, F2>) -> MoveToOptions<'b, F2>
+    where
+        F2: Fn(String, CostMatrix) -> Option<CostMatrix<'b>>,
+    {
+        let FindOptions {
+            ignore_creeps,
+            ignore_destructible_structures,
+            cost_callback,
+            max_ops,
+            heuristic_weight,
+            serialize,
+            max_rooms,
+            range,
+            plain_cost,
+            swamp_cost,
+        } = find_options;
+
+        MoveToOptions {
+            reuse_path: self.reuse_path,
+            serialize_memory: self.serialize_memory,
+            no_path_finding: self.no_path_finding,
+            // self.visualize_path_style,
+            ignore_creeps,
+            ignore_destructible_structures,
+            cost_callback,
+            max_ops,
+            heuristic_weight,
+            serialize,
+            max_rooms,
+            range,
+            plain_cost,
+            swamp_cost,
+        }
+    }
 }

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -171,6 +171,21 @@ impl Creep {
         js_unwrap!(@{self.as_ref()}.moveTo(@{&p.0}))
     }
 
+    pub fn move_to_options<'a, F, T: HasPosition>(
+        &self,
+        target: &T,
+        move_options: MoveToOptions<'a, F>,
+    ) -> ReturnCode
+    where
+        F: Fn(String, CostMatrix) -> Option<CostMatrix<'a>> + 'a,
+    {
+        let rpos = target.pos();
+        let x = rpos.x();
+        let y = rpos.y();
+
+        self.move_to_xy_options(x, y, move_options)
+    }
+
     pub fn move_by_path_serialized(&self, path: &str) -> ReturnCode {
         js_unwrap!(@{self.as_ref()}.moveByPath(@{path}))
     }

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -1,17 +1,23 @@
-use stdweb::Value;
+use std::{marker::PhantomData, mem};
+
+use stdweb::{Value, Reference};
 
 use {
     constants::{Direction, Part, ResourceType, ReturnCode},
     memory::MemoryReference,
     objects::{
-        Attackable, ConstructionSite, Creep, HasPosition, Resource, Source, StructureController,
-        StructureProperties, Transferable, Withdrawable,
+        Attackable, ConstructionSite, Creep, FindOptions, HasPosition,
+        Resource, Source, StructureController, StructureProperties, Transferable, Withdrawable,
     },
-    pathfinder::SearchResults,
+
+    pathfinder::{CostMatrix, SearchResults},
     traits::TryFrom,
+
 };
 
 use super::room::Step;
+
+scoped_thread_local!(static COST_CALLBACK: Box<Fn(String, Reference) -> Option<Reference>>);
 
 impl Creep {
     pub fn body(&self) -> Vec<Bodypart> {
@@ -77,6 +83,102 @@ impl Creep {
         js_unwrap!(@{self.as_ref()}.moveTo(@{x}, @{y}))
     }
 
+    pub fn move_to_xy_options<'a, F>(
+        &self,
+        x: u32,
+        y: u32,
+        reuse_path: Option<u32>,
+        serialize_memory: Option<bool>,
+        no_path_finding: Option<bool>,
+        find_options: Option<FindOptions<'a, F>>,
+    ) -> ReturnCode
+    where
+        F: Fn(String, CostMatrix) -> Option<CostMatrix<'a>> + 'a,
+    {
+        let rp = reuse_path.unwrap_or(5u32);
+        let sm = serialize_memory.unwrap_or(true);
+        let pf = no_path_finding.unwrap_or(false);
+        let fo: FindOptions<'a, F> = find_options.unwrap_or(FindOptions::default());
+
+        let FindOptions {
+            ignore_creeps,
+            ignore_destructible_structures,
+            cost_callback,
+            max_ops,
+            heuristic_weight,
+            serialize,
+            max_rooms,
+            range,
+            plain_cost,
+            swamp_cost,
+        } = fo;
+
+        // This callback is the one actually passed to JavaScript.
+        fn callback(room_name: String, cost_matrix: Reference) -> Option<Reference> {
+            COST_CALLBACK.with(|callback| callback(room_name, cost_matrix))
+        }
+
+        // User provided callback: rust String, CostMatrix -> Option<CostMatrix>
+        let raw_callback = cost_callback;
+
+        // Wrapped user callback: rust String, Reference -> Option<Reference>
+        let callback_boxed = move |room_name, cost_matrix_ref| {
+            let cmatrix = CostMatrix {
+                inner: cost_matrix_ref,
+                lifetime: PhantomData,
+            };
+            raw_callback(room_name, cmatrix).map(|cm| cm.inner)
+        };
+
+        // Type erased and boxed callback: no longer a type specific to the closure passed in,
+        // now unified as Box<Fn>
+        let callback_type_erased: Box<Fn(String, Reference) -> Option<Reference> + 'a> =
+            Box::new(callback_boxed);
+
+        // Overwrite lifetime of box inside closure so it can be stuck in scoped_thread_local storage:
+        // now pretending to be static data so that it can be stuck in scoped_thread_local. This should
+        // be entirely safe because we're only sticking it in scoped storage and we control the only use
+        // of it, but it's still necessary because "some lifetime above the current scope but otherwise
+        // unknown" is not a valid lifetime to have PF_CALLBACK have.
+        let callback_lifetime_erased: Box<
+            Fn(String, Reference) -> Option<Reference> + 'static,
+        > = unsafe { mem::transmute(callback_type_erased) };
+
+        // Store callback_lifetime_erased in COST_CALLBACK for the duration of the PathFinder call and
+        // make the call to PathFinder.
+        //
+        // See https://docs.rs/scoped-tls/0.1/scoped_tls/
+        COST_CALLBACK.set(&callback_lifetime_erased, || {
+            js_unwrap!{
+                @{ self.as_ref() }.moveTo(
+                    @{x},
+                    @{y},
+                    {
+                        reusePath: @{rp},
+                        serializeMemory: @{sm},
+                        noPathFinding: @{pf},
+                        visualizePathStyle: undefined,  // todo
+                        ignoreCreeps: @{ignore_creeps},
+                        ignoreDestructibleStructures: @{ignore_destructible_structures}
+                        costCallback: @{callback},
+                        maxOps: @{max_ops},
+                        heuristicWeight: @{heuristic_weight},
+                        serialize: @{serialize},
+                        maxRooms: @{max_rooms},
+                        range: @{range},
+                        plainCost: @{plain_cost},
+                        swampCost: @{swamp_cost},
+                    }
+                )
+            }
+        })
+    }
+
+    pub fn move_to<T: HasPosition>(&self, target: &T) -> ReturnCode {
+        let p = target.pos();
+        js_unwrap!(@{self.as_ref()}.moveTo(@{&p.0}))
+    }
+
     pub fn move_by_path_serialized(&self, path: &str) -> ReturnCode {
         js_unwrap!(@{self.as_ref()}.moveByPath(@{path}))
     }
@@ -111,11 +213,6 @@ impl Creep {
 
     pub fn get_active_bodyparts(&self, ty: Part) -> u32 {
         js_unwrap!(@{self.as_ref()}.getActiveBodyparts(__part_str_to_num(@{ty as u32})))
-    }
-
-    pub fn move_to<T: HasPosition>(&self, target: &T) -> ReturnCode {
-        let p = target.pos();
-        js_unwrap!(@{self.as_ref()}.moveTo(@{&p.0}))
     }
 
     pub fn ranged_mass_attack(&self) -> ReturnCode {

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -182,7 +182,7 @@ impl Room {
             ..
         } = opts;
 
-        // Store callback_lifetime_erased in PF_CALLBACK for the duration of the PathFinder call and
+        // Store callback_lifetime_erased in COST_CALLBACK for the duration of the PathFinder call and
         // make the call to PathFinder.
         //
         // See https://docs.rs/scoped-tls/0.1/scoped_tls/

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -283,16 +283,16 @@ pub struct FindOptions<'a, F>
 where
     F: Fn(String, CostMatrix) -> Option<CostMatrix<'a>>,
 {
-    ignore_creeps: bool,
-    ignore_destructible_structures: bool,
-    cost_callback: F,
-    max_ops: u32,
-    heuristic_weight: f64,
-    serialize: bool,
-    max_rooms: u32,
-    range: u32,
-    plain_cost: u8,
-    swamp_cost: u8,
+    pub(crate) ignore_creeps: bool,
+    pub(crate) ignore_destructible_structures: bool,
+    pub(crate) cost_callback: F,
+    pub(crate) max_ops: u32,
+    pub(crate) heuristic_weight: f64,
+    pub(crate) serialize: bool,
+    pub(crate) max_rooms: u32,
+    pub(crate) range: u32,
+    pub(crate) plain_cost: u8,
+    pub(crate) swamp_cost: u8,
 }
 
 impl Default for FindOptions<'static, fn(String, CostMatrix) -> Option<CostMatrix<'static>>> {

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -12,15 +12,15 @@ use {
 use super::room::{FindOptions, Path};
 
 impl RoomPosition {
-    pub fn new(x: u8, y: u8, room_name: &str) -> Self {
+    pub fn new(x: u32, y: u32, room_name: &str) -> Self {
         js_unwrap!(new RoomPosition(@{x}, @{y}, @{room_name}))
     }
 
-    pub fn x(&self) -> u8 {
+    pub fn x(&self) -> u32 {
         js_unwrap!(@{self.as_ref()}.x)
     }
 
-    pub fn y(&self) -> u8 {
+    pub fn y(&self) -> u32 {
         js_unwrap!(@{self.as_ref()}.y)
     }
 
@@ -90,7 +90,7 @@ impl RoomPosition {
         self_room.find_path(self, target, opts)
     }
 
-    pub fn find_path_to_xy<'a, F>(&self, x: u8, y: u8, opts: FindOptions<'a, F>) -> Path
+    pub fn find_path_to_xy<'a, F>(&self, x: u32, y: u32, opts: FindOptions<'a, F>) -> Path
     where
         F: Fn(String, CostMatrix) -> Option<CostMatrix<'a>> + 'a,
     {

--- a/screeps-game-api/src/positions.rs
+++ b/screeps-game-api/src/positions.rs
@@ -248,8 +248,8 @@ mod serde {
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct LocalRoomPosition {
     pub room_name: LocalRoomName,
-    pub x: u8,
-    pub y: u8,
+    pub x: u32,
+    pub y: u32,
 }
 
 impl LocalRoomPosition {
@@ -275,8 +275,8 @@ mod stdweb {
         type Error = <Value as TryInto<String>>::Error;
 
         fn try_from(v: Value) -> Result<LocalRoomPosition, Self::Error> {
-            let x: u8 = (js!{@{&v}.x}).try_into()?;
-            let y: u8 = (js!{@{&v}.y}).try_into()?;
+            let x: u32 = (js!{@{&v}.x}).try_into()?;
+            let y: u32 = (js!{@{&v}.y}).try_into()?;
             let room_name: LocalRoomName = (js!{@{&v}.roomName}).try_into()?;
 
             Ok(LocalRoomPosition { x, y, room_name })
@@ -294,8 +294,8 @@ mod room_pos_serde {
     struct SerializedLocalRoomPosition {
         room_x: i32,
         room_y: i32,
-        x: u8,
-        y: u8,
+        x: u32,
+        y: u32,
     }
 
     impl Serialize for LocalRoomPosition {


### PR DESCRIPTION
Adds an options variant to the `move_to*` methods. Those use a builder pattern to specify the options. (Thanks @daboross )

One options is left unimplemented, waiting on #46. This issue is tracked in #79.

Amongst the changes, I reverted all room position using `u8` back to `u32`. While it is true that the position will never go above 50, the conversion back-and-forth is unnecessary, especially since it probably adds runtime complexity due to the conversions.