### PR TITLE
Remove StructureSpawn::{energy, energy_capacity}

### DIFF
--- a/screeps-game-api/src/objects/impls/structure_spawn.rs
+++ b/screeps-game-api/src/objects/impls/structure_spawn.rs
@@ -9,8 +9,6 @@ use {
 
 simple_accessors! {
     StructureSpawn;
-    (energy -> energy -> i32),
-    (energy_capacity -> energyCapacity -> i32),
     (name -> name -> String),
 }
 


### PR DESCRIPTION
These are redundant with `CanStoreEnergy` which is implemented for `StructureSpawn` and provides the same method names.