### PR TITLE
Use consistent integer types, preferring u32 where nonnegative

### DIFF
--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -187,7 +187,7 @@ pub mod find {
 }
 
 enum_from_primitive! {
-    #[repr(i32)]
+    #[repr(u32)]
     #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Deserialize)]
     pub enum Direction {
         Top = 1,
@@ -201,7 +201,7 @@ enum_from_primitive! {
     }
 }
 
-impl_serialize_as_i32!(Direction);
+impl_serialize_as_u32!(Direction);
 
 impl TryFrom<Value> for Direction {
     type Error = ConversionError;
@@ -218,7 +218,7 @@ impl TryFrom<Value> for Direction {
 }
 
 enum_from_primitive! {
-    #[repr(i32)]
+    #[repr(u32)]
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     #[cfg_attr(feature = "constants-serde", derive(Deserialize))]
     pub enum Color {
@@ -236,11 +236,11 @@ enum_from_primitive! {
 }
 
 #[cfg(feature = "constants-serde")]
-impl_serialize_as_i32!(Color);
+impl_serialize_as_u32!(Color);
 
-impl From<Color> for i32 {
-    fn from(c: Color) -> i32 {
-        c as i32
+impl From<Color> for u32 {
+    fn from(c: Color) -> u32 {
+        c as u32
     }
 }
 
@@ -250,9 +250,9 @@ impl TryFrom<Value> for Color {
     fn try_from(v: Value) -> Result<Self, Self::Error> {
         use num_traits::FromPrimitive;
 
-        let as_num = i32::try_from(v)?;
+        let as_num = u32::try_from(v)?;
 
-        Ok(Self::from_i32(as_num).unwrap_or_else(|| {
+        Ok(Self::from_u32(as_num).unwrap_or_else(|| {
             panic!("encountered a color code we don't know: {}", as_num);
         }))
     }
@@ -268,7 +268,7 @@ pub enum Terrain {
 }
 
 #[cfg(feature = "constants-serde")]
-impl_serialize_as_i32!(Terrain);
+impl_serialize_as_u32!(Terrain);
 
 impl TryFrom<Value> for Terrain {
     type Error = ConversionError;
@@ -300,7 +300,7 @@ impl TryFrom<Value> for Terrain {
 /// In fact, I don't believe this can be used at all without resorting to manually
 /// including JS code.
 ///
-/// To use in JS: `__look_num_to_str(@{look as i32})` function
+/// To use in JS: `__look_num_to_str(@{look as u32})` function
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[doc(hidden)]
@@ -569,7 +569,7 @@ impl TryFrom<Value> for StructureType {
     type Error = ConversionError;
 
     fn try_from(v: Value) -> Result<Self, Self::Error> {
-        let x: i32 = v.try_into()?;
+        let x: u32 = v.try_into()?;
         Ok(match x {
             0 => StructureType::Spawn,
             1 => StructureType::Extension,
@@ -651,9 +651,9 @@ pub const GCL_POW: f32 = 2.4;
 pub const GCL_MULTIPLY: i32 = 1000000;
 pub const GCL_NOVICE: i32 = 3;
 
-pub const TERRAIN_MASK_WALL: i32 = 1;
-pub const TERRAIN_MASK_SWAMP: i32 = 2;
-pub const TERRAIN_MASK_LAVA: i32 = 4;
+pub const TERRAIN_MASK_WALL: u32 = 1;
+pub const TERRAIN_MASK_SWAMP: u32 = 2;
+pub const TERRAIN_MASK_LAVA: u32 = 4;
 
 pub const MAX_CONSTRUCTION_SITES: i32 = 100;
 pub const MAX_CREEP_SIZE: i32 = 50;
@@ -663,7 +663,7 @@ pub const MINERAL_REGEN_TIME: u32 = 50_000;
 // TODO: MINERAL_* constants
 
 enum_from_primitive! {
-    #[repr(i32)]
+    #[repr(u32)]
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub enum Density {
         DensityLow = 1,
@@ -679,9 +679,9 @@ impl TryFrom<Value> for Density {
     fn try_from(v: Value) -> Result<Self, Self::Error> {
         use num_traits::FromPrimitive;
 
-        let as_num = i32::try_from(v)?;
+        let as_num = u32::try_from(v)?;
 
-        Ok(Self::from_i32(as_num).unwrap_or_else(|| {
+        Ok(Self::from_u32(as_num).unwrap_or_else(|| {
             panic!("encountered a color code we don't know: {}", as_num);
         }))
     }
@@ -894,7 +894,7 @@ impl TryFrom<Value> for ResourceType {
     type Error = ConversionError;
 
     fn try_from(v: Value) -> Result<Self, Self::Error> {
-        let x: i32 = v.try_into()?;
+        let x: u32 = v.try_into()?;
         Ok(match x {
             1 => ResourceType::Energy,
             2 => ResourceType::Power,

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -485,7 +485,7 @@ pub const ROAD_DECAY_AMOUNT: i32 = 100;
 pub const ROAD_DECAY_TIME: u32 = 1000;
 
 pub const LINK_CAPACITY: u32 = 800;
-pub const LINK_COOLDOWN: i32 = 1;
+pub const LINK_COOLDOWN: u32 = 1;
 pub const LINK_LOSS_RATION: f32 = 0.03;
 
 pub const STORAGE_CAPACITY: u32 = 1_000_000;
@@ -613,8 +613,8 @@ pub fn controller_levels(current_rcl: i32) -> i32 {
 
 // TODO: controller_*
 
-pub const SAFE_MODE_DURATION: i32 = 20_000;
-pub const SAFE_MODE_COOLDOWN: i32 = 50_000;
+pub const SAFE_MODE_DURATION: u32 = 20_000;
+pub const SAFE_MODE_COOLDOWN: u32 = 50_000;
 pub const SAFE_MODE_COST: u32 = 1000;
 
 pub const TOWER_CAPACITY: u32 = 1000;
@@ -638,7 +638,7 @@ pub const POWER_SPAWN_ENERGY_CAPACITY: u32 = 5000;
 pub const POWER_SPAWN_POWER_CAPACITY: u32 = 100;
 pub const POWER_SPAWN_ENERGY_RATIO: u32 = 50;
 
-pub const EXTRACTOR_COOLDOWN: i32 = 5;
+pub const EXTRACTOR_COOLDOWN: u32 = 5;
 
 pub const LAB_MINERAL_CAPACITY: u32 = 3000;
 pub const LAB_ENERGY_CAPACITY: u32 = 2000;
@@ -691,7 +691,7 @@ pub const TERMINAL_CAPACITY: u32 = 300000;
 pub const TERMINAL_HITS: i32 = 3000;
 pub const TERMINAL_SEND_COST: f32 = 0.1;
 pub const TERMINAL_MIN_SEND: u32 = 100;
-pub const TERMINAL_COOLDOWN: i32 = 10;
+pub const TERMINAL_COOLDOWN: u32 = 10;
 
 pub const CONTAINER_HITS: i32 = 250000;
 pub const CONTAINER_CAPACITY: u32 = 2000;
@@ -708,7 +708,7 @@ pub const NUKE_RANGE: i32 = 10;
 
 pub const TOMBSTONE_DECAY_PER_PART: u32 = 5;
 
-pub const PORTAL_DECAY: i32 = 30000;
+pub const PORTAL_DECAY: u32 = 30000;
 
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -622,11 +622,11 @@ pub const TOWER_ENERGY_COST: u32 = 10;
 pub const TOWER_POWER_ATTACK: i32 = 600;
 pub const TOWER_POWER_HEAL: i32 = 400;
 pub const TOWER_POWER_REPAIR: i32 = 800;
-pub const TOWER_OPTIMAL_RANGE: i32 = 5;
-pub const TOWER_FALLOFF_RANGE: i32 = 20;
+pub const TOWER_OPTIMAL_RANGE: u32 = 5;
+pub const TOWER_FALLOFF_RANGE: u32 = 20;
 pub const TOWER_FALLOFF: f32 = 0.75;
 
-pub const OBSERVER_RANGE: i32 = 10;
+pub const OBSERVER_RANGE: u32 = 10;
 
 pub const POWER_BANK_CAPACITY_MAX: u32 = 5000;
 pub const POWER_BANK_CAPACITY_MIN: u32 = 500;
@@ -704,7 +704,7 @@ pub const NUKER_COOLDOWN: u32 = 100000;
 pub const NUKER_ENERGY_CAPACITY: u32 = 300000;
 pub const NUKER_GHODIUM_CAPACITY: u32 = 5000;
 pub const NUKE_LAND_TIME: u32 = 50000;
-pub const NUKE_RANGE: i32 = 10;
+pub const NUKE_RANGE: u32 = 10;
 
 pub const TOMBSTONE_DECAY_PER_PART: u32 = 5;
 

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -517,7 +517,7 @@ pub enum StructureType {
 }
 
 impl StructureType {
-    pub fn construction_cost(&self) -> i32 {
+    pub fn construction_cost(&self) -> u32 {
         use self::StructureType::*;
 
         match *self {
@@ -595,7 +595,7 @@ impl TryFrom<Value> for StructureType {
     }
 }
 
-pub const CONSTRUCTION_COST_ROAD_SWAMP_RATIO: i32 = 5;
+pub const CONSTRUCTION_COST_ROAD_SWAMP_RATIO: u32 = 5;
 
 /// Accepts levels 0-7. any other results in 0.
 pub fn controller_levels(current_rcl: u32) -> u32 {

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -655,8 +655,8 @@ pub const TERRAIN_MASK_WALL: u32 = 1;
 pub const TERRAIN_MASK_SWAMP: u32 = 2;
 pub const TERRAIN_MASK_LAVA: u32 = 4;
 
-pub const MAX_CONSTRUCTION_SITES: i32 = 100;
-pub const MAX_CREEP_SIZE: i32 = 50;
+pub const MAX_CONSTRUCTION_SITES: u32 = 100;
+pub const MAX_CREEP_SIZE: u32 = 50;
 
 pub const MINERAL_REGEN_TIME: u32 = 50_000;
 

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -418,32 +418,32 @@ pub const CREEP_CORPSE_RATE: f32 = 0.2;
 
 pub const CARRY_CAPACITY: u32 = 50;
 
-pub const HARVEST_POWER: i32 = 2;
-pub const HARVEST_MINERAL_POWER: i32 = 1;
-pub const REPAIR_POWER: i32 = 100;
-pub const DISMANTLE_POWER: i32 = 50;
-pub const BUILD_POWER: i32 = 5;
-pub const ATTACK_POWER: i32 = 30;
-pub const UPGRADE_CONTROLLER_POWER: i32 = 1;
-pub const RANGED_ATTACK_POWER: i32 = 10;
-pub const HEAL_POWER: i32 = 12;
-pub const RANGED_HEAL_POWER: i32 = 4;
+pub const HARVEST_POWER: u32 = 2;
+pub const HARVEST_MINERAL_POWER: u32 = 1;
+pub const REPAIR_POWER: u32 = 100;
+pub const DISMANTLE_POWER: u32 = 50;
+pub const BUILD_POWER: u32 = 5;
+pub const ATTACK_POWER: u32 = 30;
+pub const UPGRADE_CONTROLLER_POWER: u32 = 1;
+pub const RANGED_ATTACK_POWER: u32 = 10;
+pub const HEAL_POWER: u32 = 12;
+pub const RANGED_HEAL_POWER: u32 = 4;
 
 pub const REPAIR_COST: f32 = 0.01;
 pub const DISMANTLE_COST: f32 = 0.005;
 
-pub const RAMPART_DECAY_AMOUNT: i32 = 300;
+pub const RAMPART_DECAY_AMOUNT: u32 = 300;
 pub const RAMPART_DECAY_TIME: u32 = 100;
 
-pub const RAMPART_HITS_MAX_RCL2: i32 = 300_000;
-pub const RAMPART_HITS_MAX_RCL3: i32 = 1_000_000;
-pub const RAMPART_HITS_MAX_RCL4: i32 = 3_000_000;
-pub const RAMPART_HITS_MAX_RCL5: i32 = 5_000_000;
-pub const RAMPART_HITS_MAX_RCL6: i32 = 30_000_000;
-pub const RAMPART_HITS_MAX_RCL7: i32 = 100_000_000;
-pub const RAMPART_HITS_MAX_RCL8: i32 = 300_000_000;
+pub const RAMPART_HITS_MAX_RCL2: u32 = 300_000;
+pub const RAMPART_HITS_MAX_RCL3: u32 = 1_000_000;
+pub const RAMPART_HITS_MAX_RCL4: u32 = 3_000_000;
+pub const RAMPART_HITS_MAX_RCL5: u32 = 5_000_000;
+pub const RAMPART_HITS_MAX_RCL6: u32 = 30_000_000;
+pub const RAMPART_HITS_MAX_RCL7: u32 = 100_000_000;
+pub const RAMPART_HITS_MAX_RCL8: u32 = 300_000_000;
 
-pub fn rampart_hits_max(rcl: u32) -> i32 {
+pub fn rampart_hits_max(rcl: u32) -> u32 {
     match rcl {
         r if r < 2 => 0,
         2 => RAMPART_HITS_MAX_RCL2,
@@ -469,7 +469,7 @@ pub const SOURCE_ENERGY_CAPACITY: u32 = 3000;
 pub const SOURCE_ENERGY_NEUTRAL_CAPACITY: u32 = 1500;
 pub const SOURCE_ENERGY_KEEPER_CAPACITY: u32 = 4000;
 
-pub const WALL_HITS_MAX: i32 = 300_000_000;
+pub const WALL_HITS_MAX: u32 = 300_000_000;
 
 pub fn extension_energy_capacity(rcl: u32) -> u32 {
     match rcl {
@@ -480,8 +480,8 @@ pub fn extension_energy_capacity(rcl: u32) -> u32 {
     }
 }
 
-pub const ROAD_WEAROUT: i32 = 1;
-pub const ROAD_DECAY_AMOUNT: i32 = 100;
+pub const ROAD_WEAROUT: u32 = 1;
+pub const ROAD_DECAY_AMOUNT: u32 = 100;
 pub const ROAD_DECAY_TIME: u32 = 1000;
 
 pub const LINK_CAPACITY: u32 = 800;
@@ -540,7 +540,7 @@ impl StructureType {
         }
     }
 
-    pub fn initial_hits(&self) -> i32 {
+    pub fn initial_hits(&self) -> u32 {
         use self::StructureType::*;
 
         match *self {
@@ -619,9 +619,9 @@ pub const SAFE_MODE_COST: u32 = 1000;
 
 pub const TOWER_CAPACITY: u32 = 1000;
 pub const TOWER_ENERGY_COST: u32 = 10;
-pub const TOWER_POWER_ATTACK: i32 = 600;
-pub const TOWER_POWER_HEAL: i32 = 400;
-pub const TOWER_POWER_REPAIR: i32 = 800;
+pub const TOWER_POWER_ATTACK: u32 = 600;
+pub const TOWER_POWER_HEAL: u32 = 400;
+pub const TOWER_POWER_REPAIR: u32 = 800;
 pub const TOWER_OPTIMAL_RANGE: u32 = 5;
 pub const TOWER_FALLOFF_RANGE: u32 = 20;
 pub const TOWER_FALLOFF: f32 = 0.75;
@@ -631,7 +631,7 @@ pub const OBSERVER_RANGE: u32 = 10;
 pub const POWER_BANK_CAPACITY_MAX: u32 = 5000;
 pub const POWER_BANK_CAPACITY_MIN: u32 = 500;
 pub const POWER_BANK_CAPACITY_CRIT: f32 = 0.3;
-pub const POWER_BANK_DECAY: i32 = 5000;
+pub const POWER_BANK_DECAY: u32 = 5000;
 pub const POWER_BANK_HIT_BACK: f32 = 0.5;
 
 pub const POWER_SPAWN_ENERGY_CAPACITY: u32 = 5000;
@@ -688,18 +688,18 @@ impl TryFrom<Value> for Density {
 }
 
 pub const TERMINAL_CAPACITY: u32 = 300000;
-pub const TERMINAL_HITS: i32 = 3000;
+pub const TERMINAL_HITS: u32 = 3000;
 pub const TERMINAL_SEND_COST: f32 = 0.1;
 pub const TERMINAL_MIN_SEND: u32 = 100;
 pub const TERMINAL_COOLDOWN: u32 = 10;
 
-pub const CONTAINER_HITS: i32 = 250000;
+pub const CONTAINER_HITS: u32 = 250000;
 pub const CONTAINER_CAPACITY: u32 = 2000;
-pub const CONTAINER_DECAY: i32 = 5000;
+pub const CONTAINER_DECAY: u32 = 5000;
 pub const CONTAINER_DECAY_TIME: u32 = 100;
 pub const CONTAINER_DECAY_TIME_OWNED: u32 = 500;
 
-pub const NUKER_HITS: i32 = 1000;
+pub const NUKER_HITS: u32 = 1000;
 pub const NUKER_COOLDOWN: u32 = 100000;
 pub const NUKER_ENERGY_CAPACITY: u32 = 300000;
 pub const NUKER_GHODIUM_CAPACITY: u32 = 5000;

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -370,7 +370,7 @@ pub enum Part {
 }
 
 impl Part {
-    pub fn cost(&self) -> i32 {
+    pub fn cost(&self) -> u32 {
         // TODO: compile time feature to switch to dynamically for non-standard servers
         match *self {
             Part::Move => 50,
@@ -416,7 +416,7 @@ pub const CREEP_LIFE_TIME: u32 = 1500;
 pub const CREEP_CLAIM_LIFE_TIME: u32 = 500;
 pub const CREEP_CORPSE_RATE: f32 = 0.2;
 
-pub const CARRY_CAPACITY: i32 = 50;
+pub const CARRY_CAPACITY: u32 = 50;
 
 pub const HARVEST_POWER: i32 = 2;
 pub const HARVEST_MINERAL_POWER: i32 = 1;
@@ -458,20 +458,20 @@ pub fn rampart_hits_max(rcl: i32) -> i32 {
 }
 
 pub const ENERGY_REGEN_TIME: u32 = 300;
-pub const ENERGY_DECAY: i32 = 1000;
+pub const ENERGY_DECAY: u32 = 1000;
 
-pub const SPAWN_ENERGY_START: i32 = 300;
-pub const SPAWN_ENERGY_CAPACITY: i32 = 300;
+pub const SPAWN_ENERGY_START: u32 = 300;
+pub const SPAWN_ENERGY_CAPACITY: u32 = 300;
 pub const CREEP_SPAWN_TIME: u32 = 3;
 pub const SPAWN_RENEW_RATION: f32 = 1.2;
 
-pub const SOURCE_ENERGY_CAPACITY: i32 = 3000;
-pub const SOURCE_ENERGY_NEUTRAL_CAPACITY: i32 = 1500;
-pub const SOURCE_ENERGY_KEEPER_CAPACITY: i32 = 4000;
+pub const SOURCE_ENERGY_CAPACITY: u32 = 3000;
+pub const SOURCE_ENERGY_NEUTRAL_CAPACITY: u32 = 1500;
+pub const SOURCE_ENERGY_KEEPER_CAPACITY: u32 = 4000;
 
 pub const WALL_HITS_MAX: i32 = 300_000_000;
 
-pub fn extension_energy_capacity(rcl: i32) -> i32 {
+pub fn extension_energy_capacity(rcl: i32) -> u32 {
     match rcl {
         r if r < 7 => 50,
         7 => 100,
@@ -484,11 +484,11 @@ pub const ROAD_WEAROUT: i32 = 1;
 pub const ROAD_DECAY_AMOUNT: i32 = 100;
 pub const ROAD_DECAY_TIME: u32 = 1000;
 
-pub const LINK_CAPACITY: i32 = 800;
+pub const LINK_CAPACITY: u32 = 800;
 pub const LINK_COOLDOWN: i32 = 1;
 pub const LINK_LOSS_RATION: f32 = 0.03;
 
-pub const STORAGE_CAPACITY: i32 = 1_000_000;
+pub const STORAGE_CAPACITY: u32 = 1_000_000;
 
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -615,10 +615,10 @@ pub fn controller_levels(current_rcl: i32) -> i32 {
 
 pub const SAFE_MODE_DURATION: i32 = 20_000;
 pub const SAFE_MODE_COOLDOWN: i32 = 50_000;
-pub const SAFE_MODE_COST: i32 = 1000;
+pub const SAFE_MODE_COST: u32 = 1000;
 
-pub const TOWER_CAPACITY: i32 = 1000;
-pub const TOWER_ENERGY_COST: i32 = 10;
+pub const TOWER_CAPACITY: u32 = 1000;
+pub const TOWER_ENERGY_COST: u32 = 10;
 pub const TOWER_POWER_ATTACK: i32 = 600;
 pub const TOWER_POWER_HEAL: i32 = 400;
 pub const TOWER_POWER_REPAIR: i32 = 800;
@@ -628,24 +628,24 @@ pub const TOWER_FALLOFF: f32 = 0.75;
 
 pub const OBSERVER_RANGE: i32 = 10;
 
-pub const POWER_BANK_CAPACITY_MAX: i32 = 5000;
-pub const POWER_BANK_CAPACITY_MIN: i32 = 500;
+pub const POWER_BANK_CAPACITY_MAX: u32 = 5000;
+pub const POWER_BANK_CAPACITY_MIN: u32 = 500;
 pub const POWER_BANK_CAPACITY_CRIT: f32 = 0.3;
 pub const POWER_BANK_DECAY: i32 = 5000;
 pub const POWER_BANK_HIT_BACK: f32 = 0.5;
 
-pub const POWER_SPAWN_ENERGY_CAPACITY: i32 = 5000;
-pub const POWER_SPAWN_POWER_CAPACITY: i32 = 100;
-pub const POWER_SPAWN_ENERGY_RATIO: i32 = 50;
+pub const POWER_SPAWN_ENERGY_CAPACITY: u32 = 5000;
+pub const POWER_SPAWN_POWER_CAPACITY: u32 = 100;
+pub const POWER_SPAWN_ENERGY_RATIO: u32 = 50;
 
 pub const EXTRACTOR_COOLDOWN: i32 = 5;
 
-pub const LAB_MINERAL_CAPACITY: i32 = 3000;
-pub const LAB_ENERGY_CAPACITY: i32 = 2000;
-pub const LAB_BOOST_ENERGY: i32 = 20;
-pub const LAB_BOOST_MINERAL: i32 = 30;
+pub const LAB_MINERAL_CAPACITY: u32 = 3000;
+pub const LAB_ENERGY_CAPACITY: u32 = 2000;
+pub const LAB_BOOST_ENERGY: u32 = 20;
+pub const LAB_BOOST_MINERAL: u32 = 30;
 
-pub const LAB_REACTION_AMOUNT: i32 = 5;
+pub const LAB_REACTION_AMOUNT: u32 = 5;
 
 pub const GCL_POW: f32 = 2.4;
 pub const GCL_MULTIPLY: i32 = 1000000;
@@ -687,26 +687,26 @@ impl TryFrom<Value> for Density {
     }
 }
 
-pub const TERMINAL_CAPACITY: i32 = 300000;
+pub const TERMINAL_CAPACITY: u32 = 300000;
 pub const TERMINAL_HITS: i32 = 3000;
 pub const TERMINAL_SEND_COST: f32 = 0.1;
-pub const TERMINAL_MIN_SEND: i32 = 100;
+pub const TERMINAL_MIN_SEND: u32 = 100;
 pub const TERMINAL_COOLDOWN: i32 = 10;
 
 pub const CONTAINER_HITS: i32 = 250000;
-pub const CONTAINER_CAPACITY: i32 = 2000;
+pub const CONTAINER_CAPACITY: u32 = 2000;
 pub const CONTAINER_DECAY: i32 = 5000;
 pub const CONTAINER_DECAY_TIME: u32 = 100;
 pub const CONTAINER_DECAY_TIME_OWNED: u32 = 500;
 
 pub const NUKER_HITS: i32 = 1000;
-pub const NUKER_COOLDOWN: i32 = 100000;
-pub const NUKER_ENERGY_CAPACITY: i32 = 300000;
-pub const NUKER_GHODIUM_CAPACITY: i32 = 5000;
+pub const NUKER_COOLDOWN: u32 = 100000;
+pub const NUKER_ENERGY_CAPACITY: u32 = 300000;
+pub const NUKER_GHODIUM_CAPACITY: u32 = 5000;
 pub const NUKE_LAND_TIME: u32 = 50000;
 pub const NUKE_RANGE: i32 = 10;
 
-pub const TOMBSTONE_DECAY_PER_PART: i32 = 5;
+pub const TOMBSTONE_DECAY_PER_PART: u32 = 5;
 
 pub const PORTAL_DECAY: i32 = 30000;
 

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -443,7 +443,7 @@ pub const RAMPART_HITS_MAX_RCL6: i32 = 30_000_000;
 pub const RAMPART_HITS_MAX_RCL7: i32 = 100_000_000;
 pub const RAMPART_HITS_MAX_RCL8: i32 = 300_000_000;
 
-pub fn rampart_hits_max(rcl: i32) -> i32 {
+pub fn rampart_hits_max(rcl: u32) -> i32 {
     match rcl {
         r if r < 2 => 0,
         2 => RAMPART_HITS_MAX_RCL2,
@@ -471,7 +471,7 @@ pub const SOURCE_ENERGY_KEEPER_CAPACITY: u32 = 4000;
 
 pub const WALL_HITS_MAX: i32 = 300_000_000;
 
-pub fn extension_energy_capacity(rcl: i32) -> u32 {
+pub fn extension_energy_capacity(rcl: u32) -> u32 {
     match rcl {
         r if r < 7 => 50,
         7 => 100,
@@ -598,7 +598,7 @@ impl TryFrom<Value> for StructureType {
 pub const CONSTRUCTION_COST_ROAD_SWAMP_RATIO: i32 = 5;
 
 /// Accepts levels 0-7. any other results in 0.
-pub fn controller_levels(current_rcl: i32) -> i32 {
+pub fn controller_levels(current_rcl: u32) -> u32 {
     match current_rcl {
         1 => 200,
         2 => 45_000,
@@ -648,8 +648,8 @@ pub const LAB_BOOST_MINERAL: u32 = 30;
 pub const LAB_REACTION_AMOUNT: u32 = 5;
 
 pub const GCL_POW: f32 = 2.4;
-pub const GCL_MULTIPLY: i32 = 1000000;
-pub const GCL_NOVICE: i32 = 3;
+pub const GCL_MULTIPLY: u32 = 1000000;
+pub const GCL_NOVICE: u32 = 3;
 
 pub const TERRAIN_MASK_WALL: u32 = 1;
 pub const TERRAIN_MASK_SWAMP: u32 = 2;

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -469,6 +469,7 @@ macro_rules! construct_structure_variants {
 ///
 /// The generated implementation unconditionally uses `item as i32` to convert any instance of the
 /// structure into an integer, then uses `serialize_i32` to serialize that number.
+#[cfg(feature = "constants-serde")]
 macro_rules! impl_serialize_as_i32 {
     ($name:ty) => {
         impl ::serde::Serialize for $name {
@@ -477,6 +478,23 @@ macro_rules! impl_serialize_as_i32 {
                 S: ::serde::Serializer,
             {
                 serializer.serialize_i32(*self as i32)
+            }
+        }
+    };
+}
+
+/// Implements [`serde::Serialize`] for a single given structure name.
+///
+/// The generated implementation unconditionally uses `item as u32` to convert any instance of the
+/// structure into an integer, then uses `serialize_u32` to serialize that number.
+macro_rules! impl_serialize_as_u32 {
+    ($name:ty) => {
+        impl ::serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: ::serde::Serializer,
+            {
+                serializer.serialize_u32(*self as u32)
             }
         }
     };

--- a/screeps-game-api/src/objects/impls/construction_site.rs
+++ b/screeps-game-api/src/objects/impls/construction_site.rs
@@ -7,8 +7,8 @@ use {
 simple_accessors! {
     ConstructionSite;
     (my -> my -> bool),
-    (progress -> progress -> i32),
-    (progress_total -> progressTotal -> i32),
+    (progress -> progress -> u32),
+    (progress_total -> progressTotal -> u32),
     (structure_type -> structureType -> StructureType),
 }
 

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -36,7 +36,7 @@ impl Creep {
         body_parts
     }
 
-    pub fn carry_total(&self) -> i32 {
+    pub fn carry_total(&self) -> u32 {
         js_unwrap!(_.sum(@{self.as_ref()}.carry))
     }
 
@@ -44,7 +44,7 @@ impl Creep {
         js_unwrap!(Object.keys(@{self.as_ref()}.carry).map(__resource_type_str_to_num))
     }
 
-    pub fn carry_of(&self, ty: ResourceType) -> i32 {
+    pub fn carry_of(&self, ty: ResourceType) -> u32 {
         js_unwrap!(@{self.as_ref()}.carry[__resource_type_num_to_str(@{ty as u32})] || 0)
     }
 
@@ -57,7 +57,7 @@ impl Creep {
         }
     }
 
-    pub fn energy(&self) -> i32 {
+    pub fn energy(&self) -> u32 {
         js_unwrap!(@{self.as_ref()}.carry[RESOURCE_ENERGY])
     }
 
@@ -122,7 +122,7 @@ impl Creep {
         js_unwrap!(@{self.as_ref()}.rangedMassAttack())
     }
 
-    pub fn transfer_amount<T>(&self, target: &T, ty: ResourceType, amount: i32) -> ReturnCode
+    pub fn transfer_amount<T>(&self, target: &T, ty: ResourceType, amount: u32) -> ReturnCode
     where
         T: Transferable,
     {
@@ -143,7 +143,7 @@ impl Creep {
         ))
     }
 
-    pub fn withdraw_amount<T>(&self, target: &T, ty: ResourceType, amount: i32) -> ReturnCode
+    pub fn withdraw_amount<T>(&self, target: &T, ty: ResourceType, amount: u32) -> ReturnCode
     where
         T: Withdrawable,
     {
@@ -174,7 +174,7 @@ pub struct Bodypart {
 
 simple_accessors! {
     Creep;
-    (carry_capacity -> carryCapacity -> i32),
+    (carry_capacity -> carryCapacity -> u32),
     (fatigue -> fatigue -> i32),
     (name -> name -> String),
     (my -> my -> bool),

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -73,7 +73,7 @@ impl Creep {
         js_unwrap!(@{self.as_ref()}.move(@{dir as u32}))
     }
 
-    pub fn move_to_xy(&self, x: i32, y: i32) -> ReturnCode {
+    pub fn move_to_xy(&self, x: u32, y: u32) -> ReturnCode {
         js_unwrap!(@{self.as_ref()}.moveTo(@{x}, @{y}))
     }
 

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -45,15 +45,15 @@ impl Creep {
     }
 
     pub fn carry_of(&self, ty: ResourceType) -> i32 {
-        js_unwrap!(@{self.as_ref()}.carry[__resource_type_num_to_str(@{ty as i32})] || 0)
+        js_unwrap!(@{self.as_ref()}.carry[__resource_type_num_to_str(@{ty as u32})] || 0)
     }
 
     pub fn drop(&self, ty: ResourceType, amount: Option<u32>) -> ReturnCode {
         match amount {
             Some(v) => {
-                js_unwrap!(@{self.as_ref()}.drop(__resource_type_num_to_str(@{ty as i32}), @{v}))
+                js_unwrap!(@{self.as_ref()}.drop(__resource_type_num_to_str(@{ty as u32}), @{v}))
             }
-            None => js_unwrap!(@{self.as_ref()}.drop(__resource_type_num_to_str(@{ty as i32}))),
+            None => js_unwrap!(@{self.as_ref()}.drop(__resource_type_num_to_str(@{ty as u32}))),
         }
     }
 
@@ -70,7 +70,7 @@ impl Creep {
     }
 
     pub fn move_direction(&self, dir: Direction) -> ReturnCode {
-        js_unwrap!(@{self.as_ref()}.move(@{dir as i32}))
+        js_unwrap!(@{self.as_ref()}.move(@{dir as u32}))
     }
 
     pub fn move_to_xy(&self, x: i32, y: i32) -> ReturnCode {
@@ -110,7 +110,7 @@ impl Creep {
     }
 
     pub fn get_active_bodyparts(&self, ty: Part) -> i32 {
-        js_unwrap!(@{self.as_ref()}.getActiveBodyparts(__part_str_to_num(@{ty as i32})))
+        js_unwrap!(@{self.as_ref()}.getActiveBodyparts(__part_str_to_num(@{ty as u32})))
     }
 
     pub fn move_to<T: HasPosition>(&self, target: &T) -> ReturnCode {
@@ -128,7 +128,7 @@ impl Creep {
     {
         js_unwrap!(@{self.as_ref()}.transfer(
             @{target.as_ref()},
-            __resource_type_num_to_str(@{ty as i32}),
+            __resource_type_num_to_str(@{ty as u32}),
             @{amount}
         ))
     }
@@ -139,7 +139,7 @@ impl Creep {
     {
         js_unwrap!(@{self.as_ref()}.transfer(
             @{target.as_ref()},
-            __resource_type_num_to_str(@{ty as i32})
+            __resource_type_num_to_str(@{ty as u32})
         ))
     }
 
@@ -149,7 +149,7 @@ impl Creep {
     {
         js_unwrap!(@{self.as_ref()}.withdraw(
             @{target.as_ref()},
-            __resource_type_num_to_str(@{ty as i32}),
+            __resource_type_num_to_str(@{ty as u32}),
             @{amount}
         ))
     }
@@ -160,7 +160,7 @@ impl Creep {
     {
         js_unwrap!(@{self.as_ref()}.withdraw(
             @{target.as_ref()},
-            __resource_type_num_to_str(@{ty as i32})
+            __resource_type_num_to_str(@{ty as u32})
         ))
     }
 }

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -175,12 +175,12 @@ pub struct Bodypart {
 simple_accessors! {
     Creep;
     (carry_capacity -> carryCapacity -> u32),
-    (fatigue -> fatigue -> i32),
+    (fatigue -> fatigue -> u32),
     (name -> name -> String),
     (my -> my -> bool),
     (saying -> saying -> String),
     (spawning -> spawning -> bool),
-    (ticks_to_live -> ticksToLive -> i32),
+    (ticks_to_live -> ticksToLive -> u32),
 }
 
 creep_simple_generic_action! {

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -109,7 +109,7 @@ impl Creep {
         js_unwrap!(@{self.as_ref()}.suicide())
     }
 
-    pub fn get_active_bodyparts(&self, ty: Part) -> i32 {
+    pub fn get_active_bodyparts(&self, ty: Part) -> u32 {
         js_unwrap!(@{self.as_ref()}.getActiveBodyparts(__part_str_to_num(@{ty as u32})))
     }
 

--- a/screeps-game-api/src/objects/impls/flag.rs
+++ b/screeps-game-api/src/objects/impls/flag.rs
@@ -17,10 +17,10 @@ impl Flag {
 
     pub fn set_color(&self, color: &Color, secondary_color: Option<&Color>) {
         match secondary_color {
-            None => js! {@{self.as_ref()}.setColor(@{i32::from(*color)})},
+            None => js! {@{self.as_ref()}.setColor(@{u32::from(*color)})},
             Some(sec_color) => js! {
-                @{self.as_ref()}.setColor(@{i32::from(*color)},
-                                          @{i32::from(*sec_color)})
+                @{self.as_ref()}.setColor(@{u32::from(*color)},
+                                          @{u32::from(*sec_color)})
             },
         };
     }

--- a/screeps-game-api/src/objects/impls/resource.rs
+++ b/screeps-game-api/src/objects/impls/resource.rs
@@ -8,5 +8,5 @@ impl Resource {
 
 simple_accessors! {
     Resource;
-    (amount -> amount -> i32),
+    (amount -> amount -> u32),
 }

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -21,8 +21,8 @@ use {
 simple_accessors! {
     Room;
     (controller -> controller -> Option<StructureController>),
-    (energy_available -> energyAvailable -> i32),
-    (energy_capacity_available -> energyCapacityAvailable -> i32),
+    (energy_available -> energyAvailable -> u32),
+    (energy_capacity_available -> energyCapacityAvailable -> u32),
     (name -> name -> String),
     (storage -> storage -> Option<StructureStorage>),
     (terminal -> terminal -> Option<StructureTerminal>),

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -47,7 +47,7 @@ impl Room {
         let pos = at.pos();
         js_unwrap!(@{self.as_ref()}.createConstructionSite(
             @{pos.as_ref()},
-            __structure_type_num_to_str(@{ty as i32})
+            __structure_type_num_to_str(@{ty as u32})
         ))
     }
 
@@ -63,7 +63,7 @@ impl Room {
         let pos = at.pos();
         js_unwrap!(@{self.as_ref()}.createConstructionSite(
             @{pos.as_ref()},
-            __structure_type_num_to_str(@{ty as i32}),
+            __structure_type_num_to_str(@{ty as u32}),
             @{name}
         ))
     }
@@ -82,8 +82,8 @@ impl Room {
         js_unwrap!(@{self.as_ref()}.createFlag(
             @{pos.as_ref()},
             @{name},
-            @{main_color as i32},
-            @{secondary_color as i32}
+            @{main_color as u32},
+            @{secondary_color as u32}
         ))
     }
 
@@ -216,7 +216,7 @@ impl Room {
     {
         let pos = target.pos();
         T::convert_and_check_items(js_unwrap!(@{self.as_ref()}.lookForAt(
-            __look_num_to_str(@{ty.look_code() as i32}),
+            __look_num_to_str(@{ty.look_code() as u32}),
             @{pos.as_ref()}
         )))
     }
@@ -253,13 +253,13 @@ impl Room {
         assert!(vert.end <= 50);
 
         T::convert_and_check_items(js_unwrap!{@{self.as_ref()}.lookForAtArea(
-            __look_num_to_str(@{ty.look_code() as i32}),
+            __look_num_to_str(@{ty.look_code() as u32}),
             @{vert.start},
             @{horiz.start},
             @{vert.end},
             @{horiz.end},
             true
-        ).map((obj) => obj[__look_num_to_str(@{ty.look_code() as i32})])})
+        ).map((obj) => obj[__look_num_to_str(@{ty.look_code() as u32})])})
     }
 
     pub fn memory(&self) -> MemoryReference {

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -38,13 +38,13 @@ impl RoomPosition {
 
     pub fn create_construction_site(&self, ty: StructureType) -> ReturnCode {
         js_unwrap!(
-            @{self.as_ref()}.createConstructionSite(__structure_type_num_to_str(@{ty as i32}))
+            @{self.as_ref()}.createConstructionSite(__structure_type_num_to_str(@{ty as u32}))
         )
     }
 
     pub fn create_named_construction_site(&self, ty: StructureType, name: &str) -> ReturnCode {
         js_unwrap!(
-            @{self.as_ref()}.createConstructionSite(__structure_type_num_to_str(@{ty as i32}),
+            @{self.as_ref()}.createConstructionSite(__structure_type_num_to_str(@{ty as u32}),
                                                     @{name})
         )
     }
@@ -54,7 +54,7 @@ impl RoomPosition {
         (js! {
             var flag = @{self.as_ref()};
             if (flag.roomName in Game.rooms) {
-                return flag.createFlag(@{name}, @{main_color as i32}, @{secondary_color as i32});
+                return flag.createFlag(@{name}, @{main_color as u32}, @{secondary_color as u32});
             } else {
                 return ERR_NOT_IN_RANGE;
             }
@@ -142,7 +142,7 @@ impl RoomPosition {
         T: LookConstant,
     {
         T::convert_and_check_items(js_unwrap!{
-            @{self.as_ref()}.lookFor(__look_num_to_str(@{ty.look_code() as i32}))
+            @{self.as_ref()}.lookFor(__look_num_to_str(@{ty.look_code() as u32}))
         })
     }
 }

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -71,7 +71,7 @@ impl RoomPosition {
         )
     }
 
-    pub fn find_in_range<T>(&self, ty: T, range: i32) -> Vec<T::Item>
+    pub fn find_in_range<T>(&self, ty: T, range: u32) -> Vec<T::Item>
     where
         T: FindConstant,
     {
@@ -105,14 +105,14 @@ impl RoomPosition {
         js_unwrap!(@{self.as_ref()}.getDirectionTo(@{&target.pos().0}))
     }
 
-    pub fn get_range_to<T>(&self, target: &T) -> i32
+    pub fn get_range_to<T>(&self, target: &T) -> u32
     where
         T: HasPosition,
     {
         js_unwrap!(@{self.as_ref()}.getRangeTo(@{&target.pos().0}))
     }
 
-    pub fn in_range_to<T>(&self, target: &T, range: i32) -> bool
+    pub fn in_range_to<T>(&self, target: &T, range: u32) -> bool
     where
         T: HasPosition,
     {

--- a/screeps-game-api/src/objects/impls/structure_spawn.rs
+++ b/screeps-game-api/src/objects/impls/structure_spawn.rs
@@ -20,7 +20,7 @@ impl StructureSpawn {
     }
 
     pub fn spawn_creep(&self, body: &[Part], name: &str) -> ReturnCode {
-        let ints = body.iter().map(|p| *p as i32).collect::<Vec<i32>>();
+        let ints = body.iter().map(|p| *p as u32).collect::<Vec<u32>>();
         ((js! {
             var body = (@{ints}).map(__part_num_to_str);
 
@@ -62,7 +62,7 @@ pub struct SpawnOptions<'a> {
     memory: Option<MemoryReference>,
     energy_structures: Vec<Reference>,
     dry_run: bool,
-    directions: Vec<i32>,
+    directions: Vec<u32>,
 }
 
 impl<'a> SpawnOptions<'a> {
@@ -88,7 +88,7 @@ impl<'a> SpawnOptions<'a> {
     }
 
     pub fn directions(&mut self, directions: &[Direction]) {
-        self.directions = directions.iter().map(|d| *d as i32).collect();
+        self.directions = directions.iter().map(|d| *d as u32).collect();
     }
 
     pub fn execute(&self) -> ReturnCode {
@@ -99,7 +99,7 @@ impl<'a> SpawnOptions<'a> {
         {
             self.spawn.spawn_creep(self.body, self.name)
         } else {
-            let body = self.body.iter().map(|p| *p as i32).collect::<Vec<i32>>();
+            let body = self.body.iter().map(|p| *p as u32).collect::<Vec<u32>>();
 
             let opts = js!({});
             if let Some(mem) = self.memory.as_ref() {

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -252,7 +252,7 @@ pub unsafe trait OwnedStructureProperties: StructureProperties {
 ///
 /// If present, the `storeCapacity` property must be an integer.
 pub unsafe trait HasStore: RoomObjectProperties {
-    fn store_total(&self) -> i32 {
+    fn store_total(&self) -> u32 {
         js_unwrap!(_.sum(@{self.as_ref()}.store))
     }
 
@@ -260,15 +260,15 @@ pub unsafe trait HasStore: RoomObjectProperties {
         js_unwrap!(Object.keys(@{self.as_ref()}.store).map(__resource_type_str_to_num))
     }
 
-    fn store_of(&self, ty: ResourceType) -> i32 {
+    fn store_of(&self, ty: ResourceType) -> u32 {
         js_unwrap!(@{self.as_ref()}.store[__resource_type_num_to_str(@{ty as u32})] || 0)
     }
 
-    fn energy(&self) -> i32 {
+    fn energy(&self) -> u32 {
         js_unwrap!(@{self.as_ref()}.store[RESOURCE_ENERGY])
     }
 
-    fn store_capacity(&self) -> i32 {
+    fn store_capacity(&self) -> u32 {
         js_unwrap!(@{self.as_ref()}.storeCapacity)
     }
 }
@@ -470,7 +470,7 @@ unsafe impl HasStore for StructureContainer {}
 unsafe impl HasStore for StructureStorage {}
 unsafe impl HasStore for StructureTerminal {}
 unsafe impl HasStore for Tombstone {
-    fn store_capacity(&self) -> i32 {
+    fn store_capacity(&self) -> u32 {
         0 // no storeCapacity property
     }
 }

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -261,7 +261,7 @@ pub unsafe trait HasStore: RoomObjectProperties {
     }
 
     fn store_of(&self, ty: ResourceType) -> i32 {
-        js_unwrap!(@{self.as_ref()}.store[__resource_type_num_to_str(@{ty as i32})] || 0)
+        js_unwrap!(@{self.as_ref()}.store[__resource_type_num_to_str(@{ty as u32})] || 0)
     }
 
     fn energy(&self) -> i32 {

--- a/screeps-game-api/src/pathfinder.rs
+++ b/screeps-game-api/src/pathfinder.rs
@@ -292,7 +292,7 @@ impl SearchResults {
 pub fn search<'a, O, G, F>(
     origin: &O,
     goal: &G,
-    range: i32,
+    range: u32,
     opts: SearchOptions<'a, F>,
 ) -> SearchResults
 where
@@ -312,7 +312,7 @@ where
 pub fn search_many<'a, O, G, I, F>(origin: &O, goal: G, opts: SearchOptions<'a, F>) -> SearchResults
 where
     O: HasPosition,
-    G: IntoIterator<Item = (I, i32)>,
+    G: IntoIterator<Item = (I, u32)>,
     I: HasPosition,
     F: Fn(String) -> CostMatrix<'a> + 'a,
 {

--- a/screeps-game-api/src/pathfinder.rs
+++ b/screeps-game-api/src/pathfinder.rs
@@ -155,8 +155,8 @@ where
     plain_cost: u8,
     swamp_cost: u8,
     flee: bool,
-    max_ops: i32,
-    max_rooms: i32,
+    max_ops: u32,
+    max_rooms: u32,
     max_cost: f64,
     heuristic_weight: f64,
 }
@@ -239,13 +239,13 @@ where
     }
 
     /// Sets maximum ops - default `2000`.
-    pub fn max_ops(mut self, ops: i32) -> Self {
+    pub fn max_ops(mut self, ops: u32) -> Self {
         self.max_ops = ops;
         self
     }
 
     /// Sets maximum rooms - default `16`, max `16`.
-    pub fn max_rooms(mut self, rooms: i32) -> Self {
+    pub fn max_rooms(mut self, rooms: u32) -> Self {
         self.max_rooms = rooms;
         self
     }
@@ -265,8 +265,8 @@ where
 
 pub struct SearchResults {
     path: Array,
-    pub ops: i32,
-    pub cost: i32,
+    pub ops: u32,
+    pub cost: u32,
     pub incomplete: bool,
 }
 

--- a/screeps-game-api/src/raw_memory.rs
+++ b/screeps-game-api/src/raw_memory.rs
@@ -10,10 +10,10 @@ js_deserializable!(ForeignSegment);
 
 get_from_js!(get_active_segments -> {
     Object.keys(RawMemory.segments).map(Number)
-} -> Vec<i32>);
+} -> Vec<u32>);
 
 /// Sets active segments (max 10 ids).
-pub fn set_active_segments(ids: &[i32]) {
+pub fn set_active_segments(ids: &[u32]) {
     assert!(
         ids.len() <= 10,
         "can't set more than 10 active segments at a time"
@@ -27,7 +27,7 @@ get_from_js!(get_segment(id: u32) -> {
     RawMemory.segments[@{id}]
 } -> Option<String>);
 
-pub fn set_segment(id: i32, data: &str) {
+pub fn set_segment(id: u32, data: &str) {
     js! {
         RawMemory.segments[@{id}] = @{data};
     }
@@ -55,13 +55,13 @@ pub fn set_active_foreign_segment(username: &str, id: Option<u32>) {
     };
 }
 
-pub fn set_default_public_segment(id: i32) {
+pub fn set_default_public_segment(id: u32) {
     js! {
         RawMemory.setDefaultPublicSegment(@{id});
     }
 }
 
-pub fn set_public_segments(ids: &[i32]) {
+pub fn set_public_segments(ids: &[u32]) {
     js! {
         RawMemory.setPublicSegments(@{ids});
     }


### PR DESCRIPTION
Many things were originally all just set as i32 since in order to be the most broad without having to consider each individual case.

Now that we're cleaning up the screeps API more, this makes more things u32 where the values will always be nonnegative.

Some of these changes might be going a bit overboard - I've put everything as separate commits so they can be individually removed if we don't want to make all of these changes.