### PR TITLE
Configurable initialization header for cargo-screeps

### DIFF
--- a/cargo-screeps/README.md
+++ b/cargo-screeps/README.md
@@ -118,51 +118,13 @@ This configures general build options.
 `cargo-screeps` tries to make a reasonable `main.js` file to load the WASM. However, it's pretty
 basic, and you might find you want to do some things in JavaScript before loading the WASM module.
 
-Luckily, you can override this initialization! Set `build.initialize_header_file` to a file containing the JavaScript initialization code.
+Luckily, you can override this initialization! Set `build.initialize_header_file` to a file
+containing the JavaScript initialization code.
 
-The code will have access to two utility functions, `wasm_fetch_module_bytes` and `wasm_create_stdweb_vars`:
+Two utility functions `wasm_fetch_module_bytes` and `wasm_create_stdweb_vars` will always be
+created, but the initialization header controls what actually runs.
 
-```js
-/**
- * Fetches WASM bytes for the wasm module.
- *
- * These should be given to `new WebAssembly.Module` to instantiate a WebAssembly module.
- */
-function wasm_fetch_module_bytes() { /* ... */ }
-
-/**
- * Creates the stdweb wrapper for a module instance.
- *
- * It has two properties, `imports` and `initialize`. `imports` should be passed as the second
- * argument to `new WebAssembly.Instance` to provide the WASM module with imports, and `initialize`
- * should be called on the resulting WebAssembly instance.
- *
- * Calling `initialize` will finish associating the imports with the wasm module, and will call the
- * rust module's main function.
- */
-function wasm_create_stdweb_vars() { /* ... */ }
-```
-
-When you override the initialization, you will need to perform it yourself. Here is the default initialzation header for reference:
-
-```js
-"use strict";
-let wasm_module = null;
-
-function wasm_initialize() {
-    if (wasm_module == null) {
-        let wasm_bytes = wasm_fetch_module_bytes();
-        wasm_module = new WebAssembly.Module(wasm_bytes);
-    }
-    let stdweb_vars = wasm_create_stdweb_vars();
-    let wasm_instance = new WebAssembly.Instance(wasm_module, stdweb_vars.imports);
-    stdweb_vars.initialize(wasm_instance);
-    // assume the WASM main overrides this
-    module.exports.loop();
-}
-
-module.exports.loop = wasm_initialize;
-```
+See [docs/initialization-header.md] for more information on this.
 
 # Updating `cargo screeps`
 

--- a/cargo-screeps/README.md
+++ b/cargo-screeps/README.md
@@ -157,6 +157,8 @@ function wasm_initialize() {
     let stdweb_vars = wasm_create_stdweb_vars();
     let wasm_instance = new WebAssembly.Instance(wasm_module, stdweb_vars.imports);
     stdweb_vars.initialize(wasm_instance);
+    // assume the WASM main overrides this
+    module.exports.loop();
 }
 
 module.exports.loop = wasm_initialize;

--- a/cargo-screeps/docs/initialization-header.md
+++ b/cargo-screeps/docs/initialization-header.md
@@ -27,7 +27,7 @@ function wasm_initialize() {
         wasm_module = new WebAssembly.Module(wasm_bytes);
     }
     // Initialize `stdweb`. This returns an object with an `initialize` function and `imports`
-    // object, meant to be used as bellow:
+    // object, meant to be used as below:
     let stdweb_vars = wasm_create_stdweb_vars();
     // Create the WebAssembly instance.
     let wasm_instance = new WebAssembly.Instance(wasm_module, stdweb_vars.imports);
@@ -45,7 +45,8 @@ module.exports.loop = wasm_initialize;
 For reference, see [WebAssembly.Module] and [WebAssembly.Instance] docs.
 
 The two utility functions, `wasm_fetch_module_bytes` and `wasm_create_stdweb_vars` will always be
-generated, regardless of initialization header. Their purpose is to provide an interface to stdweb's internal initialization, and to remain stable between stdweb and cargo-web updates.
+generated, regardless of initialization header. Their purpose is to provide an interface to stdweb's
+internal initialization, and to remain stable between stdweb and cargo-web updates.
 
 They are documented as follows:
 

--- a/cargo-screeps/docs/initialization-header.md
+++ b/cargo-screeps/docs/initialization-header.md
@@ -1,0 +1,136 @@
+Writing an initialization header
+================================
+
+The initialization header is a piece of code controlling how the WASM environment starts up. As
+screeps is a resource constrained environment, and your rust code may want to interop with other
+code, this initialization is completely controllable.
+
+The default initialization header is as follows:
+
+```js
+"use strict";
+// Create a global variable to store the wasm module. This is the compiled uninstantiated code.
+// If `new WebAssembly.Instance` times out, this will helpfully remain here to be reused next tick.
+let wasm_module = null;
+
+// This function does the initialization. It's separate from `module.exports.loop` so JS code can
+// run `module.exports.loop = wasm_initialize` to reset the WASM vm next tick.
+function wasm_initialize() {
+    // If we haven't compiled the code, let's do that.
+    if (wasm_module == null) {
+        // Fetch the source byte array. `wasm_fetch_module_bytes` just returns
+        // require('wasm_module_name'), but it's useful to have as a separate function
+        // so we don't hardcode the module name.
+        let wasm_bytes = wasm_fetch_module_bytes();
+        // Compile the module. I've found that this can time out, but because of however it works,
+        // `wasm_module` will still be initialized.
+        wasm_module = new WebAssembly.Module(wasm_bytes);
+    }
+    // Initialize `stdweb`. This returns an object with an `initialize` function and `imports`
+    // object, meant to be used as bellow:
+    let stdweb_vars = wasm_create_stdweb_vars();
+    // Create the WebAssembly instance.
+    let wasm_instance = new WebAssembly.Instance(wasm_module, stdweb_vars.imports);
+    // Run the remaining stdweb initialization. This is fairly short, just some things to make sure
+    // callbacks work right and such. This will also run the rust `main` function.
+    stdweb_vars.initialize(wasm_instance);
+    // Now we run the actual main loop - this assumes that the rust `main` function overwrites
+    // `module.exports.loop`.
+    module.exports.loop();
+}
+
+module.exports.loop = wasm_initialize;
+```
+
+For reference, see [WebAssembly.Module] and [WebAssembly.Instance] docs.
+
+The two utility functions, `wasm_fetch_module_bytes` and `wasm_create_stdweb_vars` will always be
+generated, regardless of initialization header. Their purpose is to provide an interface to stdweb's internal initialization, and to remain stable between stdweb and cargo-web updates.
+
+They are documented as follows:
+
+```js
+/**
+ * Fetches WASM bytes for the wasm module.
+ *
+ * These should be given to `new WebAssembly.Module` to instantiate a WebAssembly module.
+ */
+function wasm_fetch_module_bytes() {
+    ...
+}
+
+/**
+ * Creates the stdweb wrapper for a module instance.
+ *
+ * It has two properties, `imports` and `initialize`. `imports` should be passed as the second
+ * argument to `new WebAssembly.Instance` to provide the WASM module with imports, and `initialize`
+ * should be called on the resulting WebAssembly instance.
+ *
+ * Calling `initialize` will finish associating the imports with the wasm module, and will call the
+ * rust module's main function.
+ */
+function wasm_create_stdweb_vars() {
+    ...
+}
+```
+
+## Making your own `initialization_header`
+
+To fully initialize the WASM instance, you will at minimum need to do the following things:
+
+- call `wasm_create_stdweb_vars()`
+- initialize the instance using `stdweb_vars.imports` as the import section
+  - I would recommend calling `new WebAssembly.Module` then `new WebAssembly.Instance` like the
+    default header, but there are other ways to do this, like `WebAssembly.instantiate()`
+- Call `stdweb_vars.initialize(the_instance_you_created)` to finish stdweb initialization, linking
+  all the necessary WASM and JS functions together.
+
+I would recommend using `wasm_fetch_module_bytes()` to fetch the source bytes to feed to the
+`WebAssembly.Module` constructor, but if you get them some other way that works too.
+
+The default initialization header does all these and not much else. It tries to remain utilitarian
+and do the absolute minimum to get you running.
+
+### Example: handle low bucket CPU
+
+The following will try to prevent WASM initialization from timing out. Exiting out early like this
+is a fairly standard thing to do, even in JS codebases. But at what point you want to exit out will
+depend on your codebase. 500 bucket is quite a generous amount.
+
+```js
+"use strict";
+let wasm_module = null;
+
+function wasm_initialize() {
+    if (Game.cpu.bucket < 500) {
+        return;
+    }
+    if (wasm_module == null) {
+        let wasm_bytes = wasm_fetch_module_bytes();
+        wasm_module = new WebAssembly.Module(wasm_bytes);
+    }
+    // The biggest CPU users will be the call to `new WebAssembly.Module` and
+    // `new WebAssembly.Instance`, so having two checks will be useful.
+    if (Game.cpu.bucket < 500) {
+        return;
+    }
+    let stdweb_vars = wasm_create_stdweb_vars();
+    let wasm_instance = new WebAssembly.Instance(wasm_module, stdweb_vars.imports);
+    stdweb_vars.initialize(wasm_instance);
+    module.exports.loop();
+}
+
+module.exports.loop = wasm_initialize;
+```
+
+### Beyond that
+
+I don't have many recommendations from here on out. You can inovate how you'd like, but if you'd
+rather focus on other areas of the game then the above exiting-early initialization_header should
+be fine.
+
+If you have more examples you think would be useful here, however, I'd welcome them! Pull requests
+will be accepted.
+
+[WebAssembly.Module]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module#Constructor_Syntax
+[WebAssembly.Instance]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/WebAssembly/Instance#Constructor_Syntax

--- a/cargo-screeps/docs/initialization-header.md
+++ b/cargo-screeps/docs/initialization-header.md
@@ -34,7 +34,7 @@ function wasm_initialize() {
     // Run the remaining stdweb initialization. This is fairly short, just some things to make sure
     // callbacks work right and such. This will also run the rust `main` function.
     stdweb_vars.initialize(wasm_instance);
-    // Now we run the actual main loop - this assumes that the rust `main` function overwrites
+    // Now we run the actual game loop - this assumes that the rust `main` function overwrites
     // `module.exports.loop`.
     module.exports.loop();
 }

--- a/cargo-screeps/resources/default_initialization_header.js
+++ b/cargo-screeps/resources/default_initialization_header.js
@@ -9,6 +9,8 @@ function wasm_initialize() {
     let stdweb_vars = wasm_create_stdweb_vars();
     let wasm_instance = new WebAssembly.Instance(wasm_module, stdweb_vars.imports);
     stdweb_vars.initialize(wasm_instance);
+    // assume the WASM main overrides this
+    module.exports.loop();
 }
 
 module.exports.loop = wasm_initialize;

--- a/cargo-screeps/resources/default_initialization_header.js
+++ b/cargo-screeps/resources/default_initialization_header.js
@@ -1,0 +1,14 @@
+"use strict";
+let wasm_module = null;
+
+function wasm_initialize() {
+    if (wasm_module == null) {
+        let wasm_bytes = wasm_fetch_module_bytes();
+        wasm_module = new WebAssembly.Module(wasm_bytes);
+    }
+    let stdweb_vars = wasm_create_stdweb_vars();
+    let wasm_instance = new WebAssembly.Instance(wasm_module, stdweb_vars.imports);
+    stdweb_vars.initialize(wasm_instance);
+}
+
+module.exports.loop = wasm_initialize;

--- a/cargo-screeps/src/build.rs
+++ b/cargo-screeps/src/build.rs
@@ -245,8 +245,7 @@ if( typeof Rust === "undefined" ) {
     };
 
     Ok(format!(
-        r#""use strict";
-{}
+        r#"{}
 
 /**
  * Fetches WASM bytes for the wasm module.

--- a/cargo-screeps/src/build.rs
+++ b/cargo-screeps/src/build.rs
@@ -1,11 +1,4 @@
-use std::{
-    borrow::Cow,
-    ffi::OsStr,
-    fs,
-    io::{Read, Write},
-    path::Path,
-    process,
-};
+use std::{borrow::Cow, ffi::OsStr, fs, io::Write, path::Path, process};
 
 use config::{BuildConfiguration, Configuration};
 
@@ -41,7 +34,8 @@ pub fn build(root: &Path, config: &Configuration) -> Result<(), failure::Error> 
             "build",
             "--target=wasm32-unknown-unknown",
             "--release",
-        ]).current_dir(root)
+        ])
+        .current_dir(root)
         .spawn()?
         .wait()?;
     if !cargo_success.success() {
@@ -100,17 +94,9 @@ pub fn build(root: &Path, config: &Configuration) -> Result<(), failure::Error> 
 
     debug!("processing js file");
 
-    let generated_js_contents = {
-        let mut buf = String::new();
-        fs::File::open(&generated_js)?.read_to_string(&mut buf)?;
-        buf
-    };
+    let generated_js_contents = fs::read_to_string(&generated_js)?;
 
-    let processed_js = process_js(
-        &generated_js,
-        &generated_js_contents,
-        &config.build,
-    )?;
+    let processed_js = process_js(&generated_js, &generated_js_contents, &config.build)?;
 
     let out_file = out_dir.join(&config.build.output_js_file);
 
@@ -212,7 +198,7 @@ if( typeof Rust === "undefined" ) {
     let prefix_match = expected_prefix.find(input).ok_or_else(|| {
         format_err!(
             "'cargo web' generated unexpected JS prefix! This means it's updated without \
-             'cargo screeps' also having updates. Please report this issue to \
+             'cargo screeps' also having updated. Please report this issue to \
              https://github.com/daboross/screeps-in-rust-via-wasm/issues and include \
              the first ~30 lines of {}",
             file_name.display(),
@@ -222,7 +208,7 @@ if( typeof Rust === "undefined" ) {
     let suffix_match = expected_suffix.find(input).ok_or_else(|| {
         format_err!(
             "'cargo web' generated unexpected JS suffix! This means it's updated without \
-             'cargo screeps' also having updates. Please report this issue to \
+             'cargo screeps' also having updated. Please report this issue to \
              https://github.com/daboross/screeps-in-rust-via-wasm/issues and include \
              the last ~30 lines of {}",
             file_name.display(),
@@ -243,7 +229,8 @@ if( typeof Rust === "undefined" ) {
                 "expected output_wasm_file ending in a filename, but found {}",
                 config.output_wasm_file.display()
             )
-        })?.to_str()
+        })?
+        .to_str()
         .ok_or_else(|| {
             format_err!(
                 "expected output_wasm_file with UTF8 filename, but found {}",

--- a/cargo-screeps/src/build.rs
+++ b/cargo-screeps/src/build.rs
@@ -96,7 +96,7 @@ pub fn build(root: &Path, config: &Configuration) -> Result<(), failure::Error> 
 
     let generated_js_contents = fs::read_to_string(&generated_js)?;
 
-    let processed_js = process_js(&generated_js, &generated_js_contents, &config.build)?;
+    let processed_js = process_js(&generated_js, &generated_js_contents, &root, &config.build)?;
 
     let out_file = out_dir.join(&config.build.output_js_file);
 
@@ -112,6 +112,7 @@ pub fn build(root: &Path, config: &Configuration) -> Result<(), failure::Error> 
 fn process_js(
     file_name: &Path,
     input: &str,
+    root: &Path,
     config: &BuildConfiguration,
 ) -> Result<String, failure::Error> {
     // first, strip out bootstrap code which relates to the browser. We don't want
@@ -240,7 +241,7 @@ if( typeof Rust === "undefined" ) {
 
     let initialization_header: Cow<'static, str> = match config.initialization_header_file.as_ref()
     {
-        Some(header_file) => fs::read_to_string(header_file)?.into(),
+        Some(header_file) => fs::read_to_string(root.join(header_file))?.into(),
         None => include_str!("../resources/default_initialization_header.js").into(),
     };
 

--- a/cargo-screeps/src/build.rs
+++ b/cargo-screeps/src/build.rs
@@ -248,30 +248,13 @@ if( typeof Rust === "undefined" ) {
     Ok(format!(
         r#"{}
 
-/**
- * Fetches WASM bytes for the wasm module.
- *
- * These should be given to `new WebAssembly.Module` to instantiate a WebAssembly module.
- */
 function wasm_fetch_module_bytes() {{
     "use strict";
-
     return require('{}');
 }}
 
-/**
- * Creates the stdweb wrapper for a module instance.
- *
- * It has two properties, `imports` and `initialize`. `imports` should be passed as the second
- * argument to `new WebAssembly.Instance` to provide the WASM module with imports, and `initialize`
- * should be called on the resulting WebAssembly instance.
- *
- * Calling `initialize` will finish associating the imports with the wasm module, and will call the
- * rust module's main function.
- */
 function wasm_create_stdweb_vars() {{
     "use strict";
-
     {}
 }}
 "#,

--- a/cargo-screeps/src/config.rs
+++ b/cargo-screeps/src/config.rs
@@ -171,7 +171,8 @@ impl Configuration {
         let file_config: FileConfiguration =
             serde_ignored::deserialize(&mut toml::Deserializer::new(&config_str), |unused_path| {
                 unused_paths.insert(unused_path.to_string());
-            }).context("deserializing config")?;
+            })
+            .context("deserializing config")?;
 
         for path in &unused_paths {
             warn!("unused configuration path: {}", path)

--- a/cargo-screeps/src/config.rs
+++ b/cargo-screeps/src/config.rs
@@ -10,16 +10,30 @@ use toml;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct BuildConfiguration {
+    #[serde(default = "BuildConfiguration::default_output_wasm_file")]
     pub output_wasm_file: PathBuf,
+    #[serde(default = "BuildConfiguration::default_output_js_file")]
     pub output_js_file: PathBuf,
+    #[serde(default)]
+    pub initialization_header_file: Option<PathBuf>,
 }
 
 impl Default for BuildConfiguration {
     fn default() -> Self {
         BuildConfiguration {
-            output_wasm_file: "compiled.wasm".into(),
-            output_js_file: "main.js".into(),
+            output_wasm_file: Self::default_output_wasm_file(),
+            output_js_file: Self::default_output_js_file(),
+            initialization_header_file: None,
         }
+    }
+}
+
+impl BuildConfiguration {
+    fn default_output_js_file() -> PathBuf {
+        "main.js".into()
+    }
+    fn default_output_wasm_file() -> PathBuf {
+        "compiled.wasm".into()
     }
 }
 

--- a/cargo-screeps/src/setup.rs
+++ b/cargo-screeps/src/setup.rs
@@ -35,26 +35,32 @@ fn app() -> clap::App<'static, 'static> {
                         .short("v")
                         .long("verbose")
                         .multiple(true),
-                ).arg(
+                )
+                .arg(
                     clap::Arg::with_name("config")
                         .short("c")
                         .long("config")
                         .multiple(false)
                         .takes_value(true)
                         .value_name("CONFIG_FILE"),
-                ).subcommand(
+                )
+                .subcommand(
                     clap::SubCommand::with_name("build")
                         .about("build files, put in target/ in project root"),
-                ).subcommand(
+                )
+                .subcommand(
                     clap::SubCommand::with_name("check")
                         .about("runs 'cargo check' with appropriate target"),
-                ).subcommand(
+                )
+                .subcommand(
                     clap::SubCommand::with_name("deploy")
                         .about("run default deploy action (copy or upload)"),
-                ).subcommand(
+                )
+                .subcommand(
                     clap::SubCommand::with_name("copy")
                         .about("deploy by copying files to a local directory (implies build)"),
-                ).subcommand(
+                )
+                .subcommand(
                     clap::SubCommand::with_name("upload")
                         .about("deploy by uploading files to a remote server (implies build)"),
                 ),

--- a/cargo-screeps/src/upload.rs
+++ b/cargo-screeps/src/upload.rs
@@ -66,7 +66,8 @@ pub fn upload(root: &Path, config: &Configuration) -> Result<(), failure::Error>
         .json(&RequestData {
             modules: files,
             branch: upload_config.branch.clone(),
-        }).send()?;
+        })
+        .send()?;
 
     let response_text = response.text()?;
 


### PR DESCRIPTION
Depends on #85.

Previously, `cargo-screeps` generated a fixed header in `main.js` for initializing the WASM module.

This allows changing that header on a per-project basis so as to allow including things at the user's discretion. I'm imagining this could be commonly used for things like not trying to load the WASM module if a user's bucket is below 500, or measuring exact CPU usage of each step loading the WASM.

Another use case would be integrating a rust wasm module into another project. We already allow changing the file name from `main.js` to something else, this would also allow custom initialization, for example to export things out to other modules.

## Functional changes

In addition to allowing customization, this changes the default initialization to cache the WASM module, reusing it if later initialization fails. I discovered the need for this when recently trying out a project and finding initialization timing out. The WASM module cached has no state, it's purely compiled code, so it should be completely safe.