### PR TITLE
Clean up cargo-screeps docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,25 @@ Screeps in Rust (via WASM)
 Tools for creating [Screeps] AIs written in Rust.
 
 
-`screeps-game-api` is a Rust binding to the JavaScript APIs for programs compiled to WASM using [`stdweb`].
+`screeps-game-api` is a Rust binding to the JavaScript APIs for programs compiled to WASM using
+[`stdweb`].
 
-`cargo screeps` is a binary program which wraps `cargo web` and lets one directly upload Rust WASM code to the
-Screeps server.
+`cargo screeps` is a binary program which wraps `cargo web` and lets one directly upload Rust WASM
+code to the Screeps server.
 
-These two tools go together well, but do not depend on eachother. `cargo-screeps` can compile and upload
-any screeps WASM project buildable with `stdweb`'s `cargo-web`, and `screeps-game-api` is usable in any
-project built with `cargo-web`.
+These two tools go together well, but do not depend on eachother. `cargo-screeps` can compile and
+upload any screeps WASM project buildable with `stdweb`'s `cargo-web`, and `screeps-game-api` is
+usable in any project built with `cargo-web`.
 
-Writing Screeps code in Rust can be nice, but it can also be annoying. If you have tips, tricks, or other
-things you'd like to share, make an issue! We need to write more documentation, and if we have some ideas
-of things to include, we can start an mdbook in this repository.
+Writing Screeps code in Rust can be nice, but it can also be annoying. If you have tips, tricks, or
+other things you'd like to share, make an issue! We need to write more documentation, and if we have
+enough ideas, we can start an mdbook for this repository.
+
+- [cargo screeps usage docs](cargo-screeps/README.md)
+- [screeps-game-api api docs](https://docs.rs/screeps-game-api/)
+- [screeps-starter-rust example project](https://github.com/daboross/screeps-starter-rust/)
 
 ---
-
-See https://github.com/daboross/screeps-starter-rust/ for a small example AI using these libraries.
 
 Here's a quickstart for what you *need* to get going. More documentation will be made in the future.
 
@@ -42,19 +45,6 @@ nano screeps.toml
 # build tool:
 
 cargo screeps --help
-```
-
-One more note about updating `cargo-screeps`:
-
-`cargo-screeps` is highly dependent on the version of `cargo-web`, so updating both at the same time is usually recommended. Some `cargo-web` versions might be released and break the `cargo-screeps` interface. In this case, building will fail and output a message about creating an issue on this repository.
-
-After I've updated `cargo-screeps` to work with the new `cargo-web`, you'll want to update both, then run `cargo clean` to clean out your old target directory. After all of this, you should be good to go!
-
-```sh
-cargo install -f cargo-web
-cargo install -f cargo-screeps
-cargo clean
-cargo screeps build
 ```
 
 [screeps]: https://screeps.com/

--- a/cargo-screeps/README.md
+++ b/cargo-screeps/README.md
@@ -13,7 +13,7 @@ This is not fully tested, but feel free to use! Issues are welcome.
 
 ---
 
-`cargo-screeps` build options:
+# Build Options
 
 ### `build`:
 
@@ -46,7 +46,41 @@ This is not fully tested, but feel free to use! Issues are welcome.
   - runs `cargo web --check --target=wasm32-unknown-unknown` which is fairly similar to
     `cargo check`.
 
+# Configuration Options
+
+## No namespace
+
+- `default_deploy_mode`: what `cargo screeps deploy` does: use `"copy"` or `"upload"`
+
+## `[upload]`
+
+This configures options specific to the `cargo screeps upload` deploy mode.
+
+- `username`: your Screeps username or email
+- `password`: your Screeps password. For private servers set a password using [screepsmod-auth].
+- `branch`: the branch on the server to upload files to
+- `ptr`: if true, upload to the "ptr" realm
+- `hostname`: the hostname to upload to. For example, `screeps.com` or `localhost` or `server1.screepsplu.us`
+- `ssl`: whether to connect to the server using ssl. Should be false for private servers
+- `port`: port to connect to server with. Should generally be `21025` for private servers
+
+## `[copy]`
+
+This configures options specific to the `cargo screeps copy` deploy mode.
+
+- `destination`: the directory to copy files into. can be relative to `screeps.toml` or absolute
+- `branch`: the "branch" to copy into. This is a subdirectory of `destination` which the js/wasm files will be copied into.
+- `prune`: if true, any files in the destination directory which were not just copied will be deleted after copying.
+
+## `[build]`
+
+This configures general build options.
+
+- `output_js_file`: the javascript file to export bindings and bootstrapping as (default `"main.js"`)
+- `output_wasm_file`: the WASM file to rename compile WASM to (default `"compiled.wasm"`)
+
 [cratesio-badge]: http://meritbadge.herokuapp.com/cargo-screeps
 [crate]: https://crates.io/crates/cargo-screeps/
 [`screeps-game-api`]: https://github.com/daboross/screeps-in-rust-via-wasm/
+[screepsmod-auth]: https://www.npmjs.com/package/screepsmod-auth
 

--- a/cargo-screeps/README.md
+++ b/cargo-screeps/README.md
@@ -79,6 +79,26 @@ This configures general build options.
 - `output_js_file`: the javascript file to export bindings and bootstrapping as (default `"main.js"`)
 - `output_wasm_file`: the WASM file to rename compile WASM to (default `"compiled.wasm"`)
 
+# Updating `cargo screeps`
+
+As it parses the unstable output of `cargo-web`, `cargo-screeps` is highly dependent on `cargo-web`
+version. It is recommended to upgrade both together.
+
+Installing a version of `cargo-web` newer than what `cargo-screeps` supports will cause it to
+output an error on build. If this happens, please create an issue on this repository and we can
+update `cargo-screeps`. Updating it is simple, but it needs to be done every time `cargo-web`
+changes the output format, and we might not realize that has happened.
+
+After updating, you'll want to do a full `cargo clean` to remove any old artifacts which were built
+using the older version of `cargo-web`.
+
+```sh
+cargo install -f cargo-web
+cargo install -f cargo-screeps
+cargo clean
+cargo screeps build
+```
+
 [cratesio-badge]: http://meritbadge.herokuapp.com/cargo-screeps
 [crate]: https://crates.io/crates/cargo-screeps/
 [`screeps-game-api`]: https://github.com/daboross/screeps-in-rust-via-wasm/

--- a/cargo-screeps/README.md
+++ b/cargo-screeps/README.md
@@ -52,7 +52,10 @@ This is not fully tested, but feel free to use! Issues are welcome.
 
 ## No namespace
 
-- `default_deploy_mode`: what `cargo screeps deploy` does: use `"copy"` or `"upload"`
+- `default_deploy_mode`: controls what `cargo screeps deploy` does
+
+  This configuration is required for `cargo screeps deploy`. Possible values are `"copy"`
+  and `"upload"`.
 
 ## `[upload]`
 

--- a/cargo-screeps/README.md
+++ b/cargo-screeps/README.md
@@ -17,28 +17,30 @@ This is not fully tested, but feel free to use! Issues are welcome.
 
 ### `build`:
 
-1. during build stage, shell out to https://github.com/koute/cargo-web for actual building the rust code.
-2. strip off header / surrounding function `cargo-web` generates for a generic JS file, since we know we're deploying to node
-3. append call to `__initialize` function which cargo-web generates, using `require('compiled')` to get the WASM bytes
-4. create `target/main.js` containing processed JS and copy WASM file to `target/compiled.wasm`
+1. run https://github.com/koute/cargo-web to actually build rust source
+2. strip off header / surrounding function `cargo-web` generates for a generic JS file to load from
+   web or from local filesystem
+3. append initialization call using bytes from `require('<compiled module name>')`
+4. put processed JS into `target/main.js` copy compiled WASM into `target/compiled.wasm`
 
 ### `upload`:
 
-1. run build.
+1. run build
 2. read `target/*.js` and `target/*.wasm`, keeping track of filenames
 3. read `screeps.toml` for upload options
-4. upload all read files to server, using filenames as the filenames on the server.
+4. upload all read files to server, using filenames as the filenames on the server
 
 ### `copy`:
 
-1. run build.
-2. copy compiled main file and WASM file (default `main.js` and `compiled.wasm`) from `target/` to `<destination directory>/<branch name>/`
+1. run build
+2. copy compiled main file and WASM file (default `main.js` and `compiled.wasm`) from `target/` to
+   `<destination directory>/<branch name>/`
 3. if pruning is enabled, delete all other files in `<destination directory>/<branch name>/`
 
 ### `deploy`:
 
-1. run build.
-2. run `upload` or `copy` depending on the `default_deploy_mode` configuration option.
+1. run build
+2. run `upload` or `copy` depending on the `default_deploy_mode` configuration option
 
 ### `check`:
 
@@ -54,29 +56,46 @@ This is not fully tested, but feel free to use! Issues are welcome.
 
 ## `[upload]`
 
-This configures options specific to the `cargo screeps upload` deploy mode.
+Options for the `upload` deploy mode.
+
+This section is required to use `cargo screeps upload`.
 
 - `username`: your Screeps username or email
-- `password`: your Screeps password. For private servers set a password using [screepsmod-auth].
+- `password`: your Screeps password
+
+  For private servers set a password using [screepsmod-auth].
 - `branch`: the branch on the server to upload files to
 - `ptr`: if true, upload to the "ptr" realm
-- `hostname`: the hostname to upload to. For example, `screeps.com` or `localhost` or `server1.screepsplu.us`
-- `ssl`: whether to connect to the server using ssl. Should be false for private servers
-- `port`: port to connect to server with. Should generally be `21025` for private servers
+- `hostname`: the hostname to upload to
+
+  For example, this could be `screeps.com`, `localhost` or `server1.screepsplu.us`.
+- `ssl`: whether to connect to the server using ssl
+
+  This should generally be true for the main server and false for private servers.
+- `port`: port to connect to server with
+
+  This should generally be set to `21025` for private servers.
 
 ## `[copy]`
 
-This configures options specific to the `cargo screeps copy` deploy mode.
+Options for the `copy` deploy mode.
 
-- `destination`: the directory to copy files into. can be relative to `screeps.toml` or absolute
-- `branch`: the "branch" to copy into. This is a subdirectory of `destination` which the js/wasm files will be copied into.
-- `prune`: if true, any files in the destination directory which were not just copied will be deleted after copying.
+This section is required to use `cargo screeps copy`.
+
+- `destination`: the directory to copy files into
+
+  If this path is not absolute, it is interpreted as relative to `screeps.toml`
+- `branch`: the "branch" to copy into
+
+  This is the subdirectory of `destination` which the js/wasm files will be copied into.
+- `prune`: if true, extra files found in the destination/branch directory will be deleted
 
 ## `[build]`
 
 This configures general build options.
 
-- `output_js_file`: the javascript file to export bindings and bootstrapping as (default `"main.js"`)
+- `output_js_file`: the javascript file to export bindings and bootstrapping as
+  (default `"main.js"`)
 - `output_wasm_file`: the WASM file to rename compile WASM to (default `"compiled.wasm"`)
 
 # Updating `cargo screeps`

--- a/cargo-screeps/README.md
+++ b/cargo-screeps/README.md
@@ -17,6 +17,8 @@ This is not fully tested, but feel free to use! Issues are welcome.
 
 ### `build`:
 
+Configured in `[build]` config section. No required settings.
+
 1. run https://github.com/koute/cargo-web to actually build rust source
 2. strip off header / surrounding function `cargo-web` generates for a generic JS file to load from
    web or from local filesystem
@@ -25,12 +27,16 @@ This is not fully tested, but feel free to use! Issues are welcome.
 
 ### `upload`:
 
+Requires `[upload]` config section with at minimum username, password and branch.
+
 1. run build
 2. read `target/*.js` and `target/*.wasm`, keeping track of filenames
 3. read `screeps.toml` for upload options
 4. upload all read files to server, using filenames as the filenames on the server
 
 ### `copy`:
+
+Requires `[copy]` config section with at minimum destination and branch.
 
 1. run build
 2. copy compiled main file and WASM file (default `main.js` and `compiled.wasm`) from `target/` to
@@ -39,10 +45,14 @@ This is not fully tested, but feel free to use! Issues are welcome.
 
 ### `deploy`:
 
+Requires `default_deploy_mode` configuration setting.
+
 1. run build
 2. run `upload` or `copy` depending on the `default_deploy_mode` configuration option
 
 ### `check`:
+
+Does not require configuration.
 
 1. perform type checking / lifetime checking without compiling code
   - runs `cargo web --check --target=wasm32-unknown-unknown` which is fairly similar to


### PR DESCRIPTION
This makes cargo-screeps/README.md the main location for all documentation related to `cargo-screeps`, and adds a bit more documentation for configuration options.

[Rendered `cargo-screeps/README.md`](https://github.com/daboross/screeps-in-rust-via-wasm/blob/cargo-screeps-doc-cleanup/cargo-screeps/README.md).