### PR TITLE
Implements SpawnOptions and Spawning

### DIFF
--- a/screeps-game-api/src/objects/impls/structure_spawn.rs
+++ b/screeps-game-api/src/objects/impls/structure_spawn.rs
@@ -70,7 +70,7 @@ pub struct SpawnOptions {
 }
 
 impl SpawnOptions {
-    pub fn new() -> SpawnOptions {
+    pub fn new() -> Self {
         SpawnOptions {
             memory: None,
             energy_structures: Vec::new(),
@@ -79,25 +79,29 @@ impl SpawnOptions {
         }
     }
 
-    pub fn memory<T: Into<Option<MemoryReference>>>(&mut self, mem: T) {
+    pub fn memory<T: Into<Option<MemoryReference>>>(mut self, mem: T) -> Self {
         self.memory = mem.into();
+        self
     }
 
     /// This is most useful with the `.as_structure()` method on structures.
-    pub fn energy_structures<T>(&mut self, structures: T)
+    pub fn energy_structures<T>(mut self, structures: T) -> Self
     where
         T: IntoIterator,
         <T as IntoIterator>::Item: HasEnergyForSpawn,
     {
         self.energy_structures = structures.into_iter().map(|s| s.into()).collect();
+        self
     }
 
-    pub fn dry_run(&mut self, dry_run: bool) {
+    pub fn dry_run(mut self, dry_run: bool) -> Self {
         self.dry_run = dry_run;
+        self
     }
 
-    pub fn directions(&mut self, directions: &[Direction]) {
+    pub fn directions(mut self, directions: &[Direction]) -> Self {
         self.directions = directions.iter().map(|d| *d as u32).collect();
+        self
     }
 }
 

--- a/screeps-game-api/src/objects/impls/structure_spawn.rs
+++ b/screeps-game-api/src/objects/impls/structure_spawn.rs
@@ -3,12 +3,13 @@ use stdweb::Reference;
 use {
     constants::{Direction, Part, ReturnCode},
     memory::MemoryReference,
-    objects::{Creep, StructureSpawn, HasEnergyForSpawn},
+    objects::{Creep, HasEnergyForSpawn, Spawning, StructureSpawn},
 };
 
 simple_accessors! {
     StructureSpawn;
     (name -> name -> String),
+    (spawning -> spawning -> Spawning),
 }
 
 impl StructureSpawn {
@@ -25,7 +26,12 @@ impl StructureSpawn {
         }
     }
 
-    pub fn spawn_creep_with_options(&self, body: &[Part], name: &str, opts: &SpawnOptions) -> ReturnCode {
+    pub fn spawn_creep_with_options(
+        &self,
+        body: &[Part],
+        name: &str,
+        opts: &SpawnOptions,
+    ) -> ReturnCode {
         let body = body.iter().map(|p| *p as u32).collect::<Vec<u32>>();
 
         let js_opts = js!(return {dryRun: @{opts.dry_run}};);
@@ -92,5 +98,25 @@ impl SpawnOptions {
 
     pub fn directions(&mut self, directions: &[Direction]) {
         self.directions = directions.iter().map(|d| *d as u32).collect();
+    }
+}
+
+simple_accessors! {
+    Spawning;
+    (directions -> directions -> Vec<Direction>),
+    (name -> name -> String),
+    (need_time -> needTime -> u32),
+    (remaining_time -> remainingTime -> u32),
+    (spawn -> spawn -> StructureSpawn),
+}
+
+impl Spawning {
+    pub fn cancel(&self) -> ReturnCode {
+        js_unwrap!(@{self.as_ref()}.cancel())
+    }
+
+    pub fn set_directions(&self, directions: &[Direction]) -> ReturnCode {
+        let int_dirs: Vec<u32> = directions.iter().map(|d| *d as u32).collect();
+        js_unwrap!(@{self.as_ref()}.setDirections(@{int_dirs}))
     }
 }

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -87,6 +87,8 @@ reference_wrappers!(
     StructureRoad,
     #[reference(instance_of = "StructureSpawn")]
     StructureSpawn,
+    #[reference(instance_of = "Spawning")]
+    Spawning,
     #[reference(instance_of = "StructureStorage")]
     StructureStorage,
     #[reference(instance_of = "StructureTerminal")]

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -295,8 +295,7 @@ pub unsafe trait CanStoreEnergy: StructureProperties {
 ///
 /// # Contract
 ///
-/// The reference returned from `AsRef<Reference>::as_ref` must be have an
-/// `energy` and an `energyCapacity` properties. Also, that energy can be used
+/// The reference returned from `AsRef<Reference>::as_ref` must be able to be used
 /// by a spawner to create a new creep.
 pub unsafe trait HasEnergyForSpawn: CanStoreEnergy {}
 

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -289,6 +289,15 @@ pub unsafe trait CanStoreEnergy: StructureProperties {
     }
 }
 
+/// Used to specify which structures can use their stored energy for spawning creeps.
+///
+/// # Contract
+///
+/// The reference returned from `AsRef<Reference>::as_ref` must be have an
+/// `energy` and an `energyCapacity` properties. Also, that energy can be used
+/// by a spawner to create a new creep.
+pub unsafe trait HasEnergyForSpawn: CanStoreEnergy {}
+
 /// Trait for objects which have to cooldown.
 ///
 /// # Contract
@@ -482,6 +491,9 @@ unsafe impl CanStoreEnergy for StructureNuker {}
 unsafe impl CanStoreEnergy for StructurePowerSpawn {}
 unsafe impl CanStoreEnergy for StructureSpawn {}
 unsafe impl CanStoreEnergy for StructureTower {}
+
+unsafe impl HasEnergyForSpawn for StructureExtension {}
+unsafe impl HasEnergyForSpawn for StructureSpawn {}
 
 unsafe impl HasCooldown for StructureExtractor {}
 unsafe impl HasCooldown for StructureLab {}


### PR DESCRIPTION
I modified a little bit how `SpawningOptions` worked to be more similar to the other builders we have peppered throughout the library. At the same time, I made it so it is actually supported via a `spawn_creep_with_options` method.

I also added a `Spawning(Reference)` that covers the `StructureSpawn.spawning` accessor. I was mostly done when I realized it may have made more sense to just put all the accessors within the `StructureSpawn` reference, but as we try to emulate the base API as closely as possible, I figured this would fit best.