### PR TITLE
Implements look[At][Area]()

### DIFF
--- a/screeps-game-api/src/objects/impls/mod.rs
+++ b/screeps-game-api/src/objects/impls/mod.rs
@@ -27,7 +27,7 @@ mod tombstone;
 pub use self::{
     room::{
         AttackEvent, AttackType, BuildEvent, Event, EventType, ExitEvent, FindOptions,
-        HarvestEvent, HealEvent, HealType, ObjectDestroyedEvent, Path, RepairEvent,
+        HarvestEvent, HealEvent, HealType, LookResult, ObjectDestroyedEvent, Path, RepairEvent,
         ReserveControllerEvent, Step, UpgradeControllerEvent,
     },
     structure_controller::{Reservation, Sign},

--- a/screeps-game-api/src/objects/impls/mod.rs
+++ b/screeps-game-api/src/objects/impls/mod.rs
@@ -27,8 +27,8 @@ mod tombstone;
 pub use self::{
     room::{
         AttackEvent, AttackType, BuildEvent, Event, EventType, ExitEvent, FindOptions,
-        HarvestEvent, HealEvent, HealType, LookResult, ObjectDestroyedEvent, Path, RepairEvent,
-        ReserveControllerEvent, Step, UpgradeControllerEvent,
+        HarvestEvent, HealEvent, HealType, LookResult, ObjectDestroyedEvent, Path,
+        PositionedLookResult, RepairEvent, ReserveControllerEvent, Step, UpgradeControllerEvent,
     },
     structure_controller::{Reservation, Sign},
     structure_spawn::SpawnOptions,

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -701,17 +701,19 @@ impl TryFrom<Value> for LookResult {
         let look_type: String = js!(return @{&v}.type;).try_into()?;
 
         let lr = match look_type.as_ref() {
-            "creep" => LookResult::Creep(js_unwrap!(@{v}.creep)),
-            "energy" => LookResult::Energy(js_unwrap!(@{v}.energy)),
-            "resource" => LookResult::Resource(js_unwrap!(@{v}.resource)),
-            "source" => LookResult::Source(js_unwrap!(@{v}.source)),
-            "mineral" => LookResult::Mineral(js_unwrap!(@{v}.mineral)),
-            "structure" => LookResult::Structure(js_unwrap!(@{v}.structure)),
-            "flag" => LookResult::Flag(js_unwrap!(@{v}.flag)),
-            "constructionSite" => LookResult::ConstructionSite(js_unwrap!(@{v}.constructionSite)),
-            "nuke" => LookResult::Nuke(js_unwrap!(@{v}.nuke)),
+            "creep" => LookResult::Creep(js_unwrap_ref!(@{v}.creep)),
+            "energy" => LookResult::Energy(js_unwrap_ref!(@{v}.energy)),
+            "resource" => LookResult::Resource(js_unwrap_ref!(@{v}.resource)),
+            "source" => LookResult::Source(js_unwrap_ref!(@{v}.source)),
+            "mineral" => LookResult::Mineral(js_unwrap_ref!(@{v}.mineral)),
+            "structure" => LookResult::Structure(js_unwrap_ref!(@{v}.structure)),
+            "flag" => LookResult::Flag(js_unwrap_ref!(@{v}.flag)),
+            "constructionSite" => {
+                LookResult::ConstructionSite(js_unwrap_ref!(@{v}.constructionSite))
+            }
+            "nuke" => LookResult::Nuke(js_unwrap_ref!(@{v}.nuke)),
             "terrain" => LookResult::Terrain(js_unwrap!(@{v}.terrain)),
-            "tombstone" => LookResult::Tombstone(js_unwrap!(@{v}.tombstone)),
+            "tombstone" => LookResult::Tombstone(js_unwrap_ref!(@{v}.tombstone)),
             _ => {
                 return Err(ConversionError::Custom(format!(
                     "Look result type unknown: {:?}",

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -124,13 +124,24 @@ impl Room {
         js_unwrap!(@{self.as_ref()}.getTerrain())
     }
 
-    // pub fn look_at(&self, x: u32, y: u32) -> ! {
-    //     unimplemented!()
-    // }
+    pub fn look_at<T: HasPosition>(&self, target: &T) -> Vec<LookResult> {
+        let rp = target.pos();
+        js_unwrap!(@{self.as_ref()}.lookAt(@{rp.as_ref()}))
+    }
 
-    // pub fn look_at_area(&self, top: u32, left: u32, bottom: u32, right: u32) -> ! {
-    //     unimplemented!()
-    // }
+    pub fn look_at_xy(&self, x: u32, y: u32) -> Vec<LookResult> {
+        js_unwrap!(@{self.as_ref()}.lookAt(@{x}, @{y}))
+    }
+
+    pub fn look_at_area(
+        &self,
+        top: u32,
+        left: u32,
+        bottom: u32,
+        right: u32,
+    ) -> Vec<PositionedLookResult> {
+        js_unwrap!(@{self.as_ref()}.lookAtArea(@{top}, @{left}, @{bottom}, @{right}, true))
+    }
 
     pub fn find_path<'a, O, T, F>(&self, from_pos: &O, to_pos: &T, opts: FindOptions<'a, F>) -> Path
     where
@@ -709,5 +720,23 @@ impl TryFrom<Value> for LookResult {
             }
         };
         Ok(lr)
+    }
+}
+
+pub struct PositionedLookResult {
+    pub x: u32,
+    pub y: u32,
+    pub look_result: LookResult,
+}
+
+impl TryFrom<Value> for PositionedLookResult {
+    type Error = ConversionError;
+
+    fn try_from(v: Value) -> Result<PositionedLookResult, Self::Error> {
+        let x: u32 = js!(return @{&v}.x;).try_into()?;
+        let y: u32 = js!(return @{&v}.y;).try_into()?;
+        let look_result: LookResult = v.try_into()?;
+
+        Ok(PositionedLookResult { x, y, look_result })
     }
 }

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -3,7 +3,7 @@ use std::cmp::{Eq, PartialEq};
 use {
     constants::{Color, Direction, FindConstant, LookConstant, ReturnCode},
     game,
-    objects::{HasPosition, RoomPosition, StructureType},
+    objects::{HasPosition, LookResult, RoomPosition, StructureType},
     pathfinder::CostMatrix,
     positions::LocalRoomPosition,
     traits::TryInto,
@@ -135,6 +135,10 @@ impl RoomPosition {
         T: HasPosition,
     {
         js_unwrap!(@{self.as_ref()}.isNearTo(@{&target.pos().0}))
+    }
+
+    pub fn look(&self) -> Vec<LookResult> {
+        js_unwrap!(@{self.as_ref()}.look())
     }
 
     pub fn look_for<T>(&self, ty: T) -> Vec<T::Item>

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -26,8 +26,9 @@ mod structure;
 pub use self::{
     impls::{
         AttackEvent, AttackType, BuildEvent, Event, EventType, ExitEvent, FindOptions,
-        HarvestEvent, HealEvent, HealType, LookResult, ObjectDestroyedEvent, Path, RepairEvent,
-        Reservation, ReserveControllerEvent, Sign, SpawnOptions, Step, UpgradeControllerEvent,
+        HarvestEvent, HealEvent, HealType, LookResult, ObjectDestroyedEvent, Path,
+        PositionedLookResult, RepairEvent, Reservation, ReserveControllerEvent, Sign, SpawnOptions,
+        Step, UpgradeControllerEvent,
     },
     structure::Structure,
 };

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -26,8 +26,8 @@ mod structure;
 pub use self::{
     impls::{
         AttackEvent, AttackType, BuildEvent, Event, EventType, ExitEvent, FindOptions,
-        HarvestEvent, HealEvent, HealType, ObjectDestroyedEvent, Path, RepairEvent, Reservation,
-        ReserveControllerEvent, Sign, SpawnOptions, Step, UpgradeControllerEvent,
+        HarvestEvent, HealEvent, HealType, LookResult, ObjectDestroyedEvent, Path, RepairEvent,
+        Reservation, ReserveControllerEvent, Sign, SpawnOptions, Step, UpgradeControllerEvent,
     },
     structure::Structure,
 };


### PR DESCRIPTION
Closes #81 

Introduces two new structs: `LookResult` used for `look` and `lookAt` and `PositionedLookResult` for `lookAtArea`. Both have a manual `TryFrom<Value>` used for conversion.