### PR TITLE
Release cargo-screeps 0.2.1.

### DIFF
--- a/cargo-screeps/Cargo.toml
+++ b/cargo-screeps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-screeps"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["David Ross <daboross@daboross.net>"]
 documentation = "https://github.com/daboross/screeps-in-rust-via-wasm/cargo-screeps/"
 include = [


### PR DESCRIPTION
Changelog for this release:

> Release cargo-screeps version 0.2.1
> 
> - Update expected format to match `cargo-web` version `0.6.19`
> - Fix subcommand documentation in README

Fixes #89. #75 was merged, but not released.