### PR TITLE
Fix JavaScript code in StructureSpawn methods

### DIFF
--- a/screeps-game-api/src/objects/impls/structure_spawn.rs
+++ b/screeps-game-api/src/objects/impls/structure_spawn.rs
@@ -35,7 +35,7 @@ impl StructureSpawn {
         name: &str,
         opts: &SpawnOptions,
     ) -> ReturnCode {
-        let body = body.iter().map(|p| *p as u32).collect::<Vec<u32>>();
+        let body_ints = body.iter().map(|p| *p as u32).collect::<Vec<u32>>();
 
         let js_opts = js!(return {dryRun: @{opts.dry_run}};);
 
@@ -48,7 +48,13 @@ impl StructureSpawn {
         if !opts.directions.is_empty() {
             js!(@{&js_opts}.directions = @{&opts.directions};);
         }
-        js_unwrap!(@{self.as_ref()}.spawnCreep(@{body}, @{name}, @{js_opts}))
+        (js! {
+            var body = (@{body_ints}).map(__part_num_to_str);
+
+            return @{self.as_ref()}.spawnCreep(body, @{name}, @{js_opts});
+        })
+        .try_into()
+        .expect("expected StructureSpawn::spawnCreep to return an integer return code")
     }
 
     // TODO: support actually using Spawning properties.

--- a/screeps-game-api/src/objects/impls/structure_spawn.rs
+++ b/screeps-game-api/src/objects/impls/structure_spawn.rs
@@ -4,6 +4,7 @@ use {
     constants::{Direction, Part, ReturnCode},
     memory::MemoryReference,
     objects::{Creep, HasEnergyForSpawn, Spawning, StructureSpawn},
+    traits::TryInto,
 };
 
 simple_accessors! {
@@ -19,11 +20,13 @@ impl StructureSpawn {
 
     pub fn spawn_creep(&self, body: &[Part], name: &str) -> ReturnCode {
         let ints = body.iter().map(|p| *p as u32).collect::<Vec<u32>>();
-        js_unwrap! {
+        (js! {
             var body = (@{ints}).map(__part_num_to_str);
 
             return @{self.as_ref()}.spawnCreep(body, @{name});
-        }
+        })
+        .try_into()
+        .expect("expected StructureSpawn::spawnCreep to return an integer return code")
     }
 
     pub fn spawn_creep_with_options(


### PR DESCRIPTION
Two small fixes for `spawn_creep` and `spawn_creep_with_options` actually working.

I should have caught the first one when it was merged, but completely overlooked it. Really makes me wish we had CI/minimal testing of javascript interaction part of this, but that would be a huge pain to set up with the screeps runtime.

In the meantime, testing by running the latest version in a personal ai works! and it catches things like this.

See individual commits for descriptions of why changes were made. 