### PR TITLE
Fix mem_get! + misc. test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ script:
 - (cd cargo-screeps && cargo build --all-features --verbose)
 - (cd cargo-screeps && cargo test --all-features --verbose)
 - (cd screeps-game-api && cargo build --release --target=wasm32-unknown-unknown --verbose)
+- (cd screeps-game-api && cargo test --verbose)

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -513,7 +513,7 @@ macro_rules! impl_serialize_as_u32 {
 ///
 /// # fn main() {
 /// let mem = screeps::memory::root();
-/// let val = mem_get!(mem.creeps.John.count.int);
+/// let val = mem_get!(mem.creeps.John.count.i32);
 /// # }
 /// ```
 ///
@@ -527,8 +527,8 @@ macro_rules! impl_serialize_as_u32 {
 /// let mem = screeps::memory::root();
 /// let creep_name = "John";
 /// let what_to_get = "count";
-/// let val1 = mem_get!(mem.creeps[creep_name][what_to_get].int);
-/// let val2 = mem_get!(mem.creeps[creep_name].count.int);
+/// let val1 = mem_get!(mem.creeps[creep_name][what_to_get].i32);
+/// let val2 = mem_get!(mem.creeps[creep_name].count.i32);
 /// assert_eq!(val1, val2);
 /// # }
 /// ```

--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -539,21 +539,30 @@ macro_rules! impl_serialize_as_u32 {
 macro_rules! mem_get {
     // Macro entry point
     ($memory_reference:ident $($rest:tt)*) => {
-        mem_get!(@so_far { Some(&$memory_reference) } @rest $($rest)*)
+        mem_get!(@so_far { Ok(Some(&$memory_reference)) } @rest $($rest)*)
     };
     // Access the last part with a variable
     (@so_far { $reference_so_far:expr } @rest [ $final_part_variable:expr ] . $accessor:ident) => {
-        $reference_so_far.and_then(|v| v.$accessor($final_part_variable))
+        $reference_so_far.and_then(|opt| match opt {
+            Some(v) => v.$accessor($final_part_variable),
+            None => Ok(None),
+        })
     };
     // Access the last part with a hardcoded ident
     (@so_far { $reference_so_far:expr } @rest . $final_part:ident . $accessor:ident) => {
-        $reference_so_far.and_then(|v| v.$accessor(stringify!($final_part)))
+        $reference_so_far.and_then(|opt| match opt {
+            Some(v) => v.$accessor(stringify!($final_part)),
+            None => Ok(None),
+        })
     };
     // Access the next (but not last) part with a variable
     (@so_far { $reference_so_far:expr } @rest [ $next_part_variable:expr ] $($rest:tt)+) => {
         mem_get!(
             @so_far {
-                $reference_so_far.and_then(|v| v.dict($next_part_variable))
+                $reference_so_far.and_then(|opt| match opt {
+                    Some(v) => v.dict($next_part_variable),
+                    None => Ok(None),
+                })
             }
             @rest $($rest)*
         )
@@ -562,7 +571,10 @@ macro_rules! mem_get {
     (@so_far { $reference_so_far:expr } @rest . $next_part:ident $($rest:tt)+) => {
         mem_get!(
             @so_far {
-                $reference_so_far.and_then(|v| v.dict(stringify!($next_part)))
+                $reference_so_far.and_then(|opt| match opt {
+                    Some(v) => v.dict(stringify!($next_part)),
+                    None => Ok(None),
+                })
             }
             @rest $($rest)*
         )

--- a/screeps-game-api/src/memory.rs
+++ b/screeps-game-api/src/memory.rs
@@ -25,7 +25,7 @@
 //! be accessed using the `object["key"]` javascript syntax using type methods.
 //! ```no_run
 //! let mem = screeps::memory::root();
-//! let cpu_used_last_tick = mem.int("cpu_used_last_tick").unwrap();
+//! let cpu_used_last_tick = mem.i32("cpu_used_last_tick").unwrap();
 //! ```
 //!
 //! ## Accessing memory with a _path_
@@ -41,7 +41,7 @@
 //! depending on the method used. For example,
 //! ```no_run
 //! let mem = screeps::memory::root();
-//! let creep_time = mem.path_num("creeps.John.time").unwrap();
+//! let creep_time = mem.path_i32("creeps.John.time").unwrap();
 //! ```
 //!
 //! # Other methods that provide `MemoryReference`s

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -253,9 +253,10 @@ impl Room {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # let room: ::screeps::Room = unimplemented!();
     /// use screeps::constants::look;
-    /// room.look_for_at_area(look::ENERGY, 20..26, 20..26)
+    /// room.look_for_at_area(look::ENERGY, 20..26, 20..26);
     /// ```
     pub fn look_for_at_area<T>(&self, ty: T, horiz: Range<u8>, vert: Range<u8>) -> Vec<T::Item>
     where


### PR DESCRIPTION
`cargo test` has been failing for a while, and it just isn't tested by travis.

This fixes an underlying issue with `mem_get!` which was causing the tests to fail, and then fixes other issues with doc tests.

Finally, `cargo test` is added to travis to ensure these doc examples/tests stay up to date in the future.