### PR TITLE
Pass HasPosition by reference whenever possible

### DIFF
--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -43,7 +43,7 @@ impl Room {
         js_unwrap!{@{self.as_ref()}.deserializePath(@{path})}
     }
 
-    pub fn create_construction_site<T>(&self, at: T, ty: StructureType) -> ReturnCode
+    pub fn create_construction_site<T>(&self, at: &T, ty: StructureType) -> ReturnCode
     where
         T: HasPosition,
     {
@@ -56,7 +56,7 @@ impl Room {
 
     pub fn create_named_construction_site<T>(
         &self,
-        at: T,
+        at: &T,
         ty: StructureType,
         name: &str,
     ) -> ReturnCode
@@ -73,7 +73,7 @@ impl Room {
 
     pub fn create_flag<T>(
         &self,
-        at: T,
+        at: &T,
         name: &str,
         main_color: Color,
         secondary_color: Color,
@@ -223,7 +223,7 @@ impl Room {
         })
     }
 
-    pub fn look_for_at<T, U>(&self, ty: T, target: U) -> Vec<T::Item>
+    pub fn look_for_at<T, U>(&self, ty: T, target: &U) -> Vec<T::Item>
     where
         T: LookConstant,
         U: HasPosition,


### PR DESCRIPTION
Taking HasPosition things by value doesn't have much purpose, because the only method available on `HasPosition` takes `&self`. At least that's my reasoning?

We don't have any `impl<T> HasPosition for &T where T: HasPosition`. If we did, this would be unnecessary. I think taking `&T` in methods is simpler than this blanket impl, though, especially since we already have another blanket impl which would have to be removed if we added this one.