### PR TITLE
Fix Room::name_local() method panicking in sim.

### DIFF
--- a/screeps-game-api/src/positions.rs
+++ b/screeps-game-api/src/positions.rs
@@ -111,6 +111,10 @@ pub trait IntoLocalRoomName {
 }
 
 fn parse_or_cheap_failure(s: &str) -> Result<LocalRoomName, ()> {
+    if s == "sim" {
+        return Ok(LocalRoomName { x_coord: 0, y_coord: 0 })
+    }
+
     let mut chars = s.char_indices();
 
     let east = match chars.next() {


### PR DESCRIPTION
This makes `room_local` compatible with simulation room.