### PR TITLE
Removing allocation from PathFinder.search and Room.find calls

### DIFF
--- a/screeps-game-api/CHANGELOG.md
+++ b/screeps-game-api/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 - Take `&T` in `Room::create_construction_site` and `look_for_at` rather than `T` for
   `T: HasPosition` (breaking) (#105)
 - Add `Neg` implementation for `Direction` allowing unary minus to reverse direction (#113)
+- Remove unnecessary allocation from PathFinder and Room.find calls (#112)
 - Add `JsVec` structure for transparently wrapping typed JavaScript arrays without immediately
   unwrapping them. (#114)
 

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -174,11 +174,11 @@ impl Room {
         let callback_type_erased: &(Fn(String, Reference) -> Option<Reference> + 'a) =
             &callback_boxed;
 
-        // Overwrite lifetime of box inside closure so it can be stuck in scoped_thread_local
-        // storage: now pretending to be static data so that it can be stuck in scoped_thread_local.
-        // This should be entirely safe because we're only sticking it in scoped storage and we
-        // control the only use of it, but it's still necessary because "some lifetime above the
-        // current scope but otherwise unknown" is not a valid lifetime to have PF_CALLBACK have.
+        // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
+        // storage: it's now pretending to be static data. This should be entirely safe because
+        // we're only sticking it in scoped storage and we control the only use of it, but it's
+        // still necessary because "some lifetime above the  current scope but otherwise unknown" is
+        // not a valid lifetime to have PF_CALLBACK have.
         let callback_lifetime_erased: &'static Fn(String, Reference) -> Option<Reference> =
             unsafe { mem::transmute(callback_type_erased) };
 

--- a/screeps-game-api/src/pathfinder.rs
+++ b/screeps-game-api/src/pathfinder.rs
@@ -335,7 +335,7 @@ where
     search_real(&origin.pos(), &goals_js, opts)
 }
 
-scoped_thread_local!(static PF_CALLBACK: Box<(Fn(String) -> Reference)>);
+scoped_thread_local!(static PF_CALLBACK: &'static Fn(String) -> Reference);
 
 fn search_real<'a, F>(
     origin: &RoomPosition,
@@ -360,15 +360,15 @@ where
     let callback_unboxed = move |input| raw_callback(input).inner;
 
     // Type erased and boxed callback: no longer a type specific to the closure passed in,
-    // now unified as Box<Fn>
-    let callback_type_erased: Box<Fn(String) -> Reference + 'a> = Box::new(callback_unboxed);
+    // now unified as &Fn
+    let callback_type_erased: &(Fn(String) -> Reference + 'a) = &callback_unboxed;
 
     // Overwrite lifetime of box inside closure so it can be stuck in scoped_thread_local storage:
     // now pretending to be static data so that it can be stuck in scoped_thread_local. This should
     // be entirely safe because we're only sticking it in scoped storage and we control the only use
     // of it, but it's still necessary because "some lifetime above the current scope but otherwise
     // unknown" is not a valid lifetime to have PF_CALLBACK have.
-    let callback_lifetime_erased: Box<Fn(String) -> Reference + 'static> =
+    let callback_lifetime_erased: &'static Fn(String) -> Reference =
         unsafe { mem::transmute(callback_type_erased) };
 
     let SearchOptions {

--- a/screeps-game-api/src/pathfinder.rs
+++ b/screeps-game-api/src/pathfinder.rs
@@ -363,11 +363,11 @@ where
     // now unified as &Fn
     let callback_type_erased: &(Fn(String) -> Reference + 'a) = &callback_unboxed;
 
-    // Overwrite lifetime of box inside closure so it can be stuck in scoped_thread_local storage:
-    // now pretending to be static data so that it can be stuck in scoped_thread_local. This should
-    // be entirely safe because we're only sticking it in scoped storage and we control the only use
-    // of it, but it's still necessary because "some lifetime above the current scope but otherwise
-    // unknown" is not a valid lifetime to have PF_CALLBACK have.
+    // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
+    // storage: it's now pretending to be static data. This should be entirely safe because we're
+    // only sticking it in scoped storage and we control the only use of it, but it's still
+    // necessary because "some lifetime above the current scope but otherwise unknown" is not a
+    // valid lifetime to have PF_CALLBACK have.
     let callback_lifetime_erased: &'static Fn(String) -> Reference =
         unsafe { mem::transmute(callback_type_erased) };
 


### PR DESCRIPTION
This is slightly more unsafe code, but should still be sound. The principal is the same as transmuting `'a` to `'static` - it just affects the reference to the `Fn` as well now, not just the lifetime of the data within the box.

The actual change is that instead of allocating a space for the callback on the heap and storing a pointer to it, we just store a pointer to the stack location it's in within the pathfinder function. This change is made for both `Room.find` and `PathFinder.search`.