### PR TITLE
Add local utility for reversing directions

### DIFF
--- a/screeps-game-api/CHANGELOG.md
+++ b/screeps-game-api/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ==========
 
+- Add `Neg` implementation for `Direction` (`-Top` produces `Bottom`)
 
 0.3.0 (2018-11-??)
 ==================

--- a/screeps-game-api/CHANGELOG.md
+++ b/screeps-game-api/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased
 ==========
 
-- Add `Neg` implementation for `Direction` (`-Top` produces `Bottom`)
+- Add `Neg` implementation for `Direction` allowing unary minus to reverse direction (#113)
 
 0.3.0 (2018-11-??)
 ==================

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -217,6 +217,25 @@ impl TryFrom<Value> for Direction {
     }
 }
 
+impl ::std::ops::Neg for Direction {
+    type Output = Direction;
+
+    fn neg(self) -> Direction {
+        use Direction::*;
+
+        match self {
+            Top => Bottom,
+            TopRight => BottomLeft,
+            Right => Left,
+            BottomRight => TopLeft,
+            Bottom => Top,
+            BottomLeft => TopRight,
+            Left => Right,
+            TopLeft => BottomRight,
+        }
+    }
+}
+
 #[repr(u32)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, FromPrimitive)]
 #[cfg_attr(feature = "constants-serde", derive(Deserialize))]

--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -220,6 +220,17 @@ impl TryFrom<Value> for Direction {
 impl ::std::ops::Neg for Direction {
     type Output = Direction;
 
+    /// Negates this direction. Top goes to Bottom, TopRight goes to BottomLeft, etc.
+    ///
+    /// Example usage:
+    ///
+    /// ```
+    /// use screeps::Direction::*;
+    ///
+    /// assert_eq!(-Top, Bottom);
+    /// assert_eq!(-BottomRight, TopLeft);
+    /// assert_eq!(-Left, Right);
+    /// ```
     fn neg(self) -> Direction {
         use Direction::*;
 


### PR DESCRIPTION
I'm not sure how many "nice" things we should add to this repository, but I hope this isn't too much.

It implements `Not` for `Direction` to allow using `-direction`. `-direction` will point in the opposite direction (`-Top == Bottom`, `-Right == Left`, etc.).