### PR TITLE
Fix Attackable impl on Structure for controllers

### DIFF
--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -385,7 +385,6 @@ unsafe impl Withdrawable for Tombstone {}
 
 unsafe impl Attackable for Creep {}
 unsafe impl Attackable for OwnedStructure {}
-unsafe impl Attackable for Structure {}
 unsafe impl Attackable for StructureContainer {}
 unsafe impl Attackable for StructureExtension {}
 unsafe impl Attackable for StructureExtractor {}

--- a/screeps-game-api/src/objects/structure.rs
+++ b/screeps-game-api/src/objects/structure.rs
@@ -91,3 +91,19 @@ impl ReferenceType for Structure {
         )
     }
 }
+
+unsafe impl Attackable for Structure {
+    fn hits(&self) -> u32 {
+        match self {
+            Structure::Controller(_) => 0,
+            _ => js_unwrap! { @{self.as_ref()}.hits },
+        }
+    }
+
+    fn hits_max(&self) -> u32 {
+        match self {
+            Structure::Controller(_) => 0,
+            _ => js_unwrap! { @{self.as_ref()}.hitsMax },
+        }
+    }
+}


### PR DESCRIPTION
This implements the fix "just return 0 for controllers for hits and hits_max". Note that `StructureController` still lacks an `Attackable` implementation- it's just on a `Structure` that this happens.

See https://github.com/daboross/screeps-in-rust-via-wasm/issues/118#issuecomment-452740686.