### PR TITLE
Fix travis (2nd attempt)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ install:
         https://github.com/koute/cargo-web/releases/latest)
     cargo_web_version=$(echo $cargo_web_release \
         | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
-    case "$TRAVIS_OS_NAME" in
-      osx) cargo_web_host_triple="x86_64-apple-darwin" ;;
-      linux) cargo_web_host_triple="x86_64-unknown-linux-gnu" ;;
-    esac
+    if [ "$(uname -s)" == "Darwin" ]; then
+      cargo_web_host_triple="x86_64-apple-darwin"
+    else
+      cargo_web_host_triple="x86_64-unknown-linux-gnu"
+    fi
     cargo_web_url_prefix="https://github.com/koute/cargo-web/releases/download/"
     cargo_web_url="$cargo_web_version/cargo-web-$cargo_web_host_triple.gz"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ install:
     else
       cargo_web_host_triple="x86_64-unknown-linux-gnu"
     fi
-    cargo_web_url_prefix="https://github.com/koute/cargo-web/releases/download/"
-    cargo_web_url="$cargo_web_version/cargo-web-$cargo_web_host_triple.gz"
+    cargo_web_url_prefix="https://github.com/koute/cargo-web/releases/download"
+    cargo_web_url="$cargo_web_url_prefix/$cargo_web_version/cargo-web-$cargo_web_host_triple.gz"
 
     echo "Downloading cargo-web from: $cargo_web_url"
     curl -L "$cargo_web_url" | gzip -d > cargo-web


### PR DESCRIPTION
After #111, travis appears to work, but I believe I actually broke it directly after fixing it, and it's only working currently because of a cached binary...

This incorporates the changes made to https://github.com/koute/cargo-web/pull/167 to use non-travis-specific OS detection and fixes the bug in my last attempted fix which didn't actually prepend "https://github.com/.../download/" to the URL being downloaded.