### PR TITLE
Make `as_*` methods usable, and remove Attackable from Structure

### DIFF
--- a/screeps-game-api/src/macros.rs
+++ b/screeps-game-api/src/macros.rs
@@ -293,7 +293,7 @@ macro_rules! creep_simple_generic_action {
             $(
                 pub fn $method<T>(&self, target: &T) -> ReturnCode
                 where
-                    T: $trait,
+                    T: ?Sized + $trait,
                 {
                     js_unwrap!(@{self.as_ref()}.$js_name(@{target.as_ref()}))
                 }

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -94,17 +94,18 @@ impl Creep {
         self.move_to_with_options(&rp, move_options)
     }
 
-    pub fn move_to<T: HasPosition>(&self, target: &T) -> ReturnCode {
+    pub fn move_to<T: ?Sized + HasPosition>(&self, target: &T) -> ReturnCode {
         let p = target.pos();
         js_unwrap!(@{self.as_ref()}.moveTo(@{&p.0}))
     }
 
-    pub fn move_to_with_options<'a, F, T: HasPosition>(
+    pub fn move_to_with_options<'a, F, T>(
         &self,
         target: &T,
         move_options: MoveToOptions<'a, F>,
     ) -> ReturnCode
     where
+        T: ?Sized + HasPosition,
         F: Fn(String, CostMatrix) -> Option<CostMatrix<'a>> + 'a,
     {
         let MoveToOptions {
@@ -230,7 +231,7 @@ impl Creep {
 
     pub fn transfer_amount<T>(&self, target: &T, ty: ResourceType, amount: u32) -> ReturnCode
     where
-        T: Transferable,
+        T: ?Sized + Transferable,
     {
         js_unwrap!(@{self.as_ref()}.transfer(
             @{target.as_ref()},
@@ -241,7 +242,7 @@ impl Creep {
 
     pub fn transfer_all<T>(&self, target: &T, ty: ResourceType) -> ReturnCode
     where
-        T: Transferable,
+        T: ?Sized + Transferable,
     {
         js_unwrap!(@{self.as_ref()}.transfer(
             @{target.as_ref()},
@@ -251,7 +252,7 @@ impl Creep {
 
     pub fn withdraw_amount<T>(&self, target: &T, ty: ResourceType, amount: u32) -> ReturnCode
     where
-        T: Withdrawable,
+        T: ?Sized + Withdrawable,
     {
         js_unwrap!(@{self.as_ref()}.withdraw(
             @{target.as_ref()},
@@ -262,7 +263,7 @@ impl Creep {
 
     pub fn withdraw_all<T>(&self, target: &T, ty: ResourceType) -> ReturnCode
     where
-        T: Withdrawable,
+        T: ?Sized + Withdrawable,
     {
         js_unwrap!(@{self.as_ref()}.withdraw(
             @{target.as_ref()},

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -45,7 +45,7 @@ impl Room {
 
     pub fn create_construction_site<T>(&self, at: &T, ty: StructureType) -> ReturnCode
     where
-        T: HasPosition,
+        T: ?Sized + HasPosition,
     {
         let pos = at.pos();
         js_unwrap!(@{self.as_ref()}.createConstructionSite(
@@ -61,7 +61,7 @@ impl Room {
         name: &str,
     ) -> ReturnCode
     where
-        T: HasPosition,
+        T: ?Sized + HasPosition,
     {
         let pos = at.pos();
         js_unwrap!(@{self.as_ref()}.createConstructionSite(
@@ -79,7 +79,7 @@ impl Room {
         secondary_color: Color,
     ) -> ReturnCode
     where
-        T: HasPosition,
+        T: ?Sized + HasPosition,
     {
         let pos = at.pos();
         js_unwrap!(@{self.as_ref()}.createFlag(
@@ -124,7 +124,7 @@ impl Room {
         js_unwrap!(@{self.as_ref()}.getTerrain())
     }
 
-    pub fn look_at<T: HasPosition>(&self, target: &T) -> Vec<LookResult> {
+    pub fn look_at<T: ?Sized + HasPosition>(&self, target: &T) -> Vec<LookResult> {
         let rp = target.pos();
         js_unwrap!(@{self.as_ref()}.lookAt(@{rp.as_ref()}))
     }
@@ -145,8 +145,8 @@ impl Room {
 
     pub fn find_path<'a, O, T, F>(&self, from_pos: &O, to_pos: &T, opts: FindOptions<'a, F>) -> Path
     where
-        O: HasPosition,
-        T: HasPosition,
+        O: ?Sized + HasPosition,
+        T: ?Sized + HasPosition,
         F: Fn(String, CostMatrix) -> Option<CostMatrix<'a>> + 'a,
     {
         let from = from_pos.pos();

--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -80,7 +80,7 @@ impl RoomPosition {
     pub fn find_path_to<'a, F, T>(&self, target: &T, opts: FindOptions<'a, F>) -> Path
     where
         F: Fn(String, CostMatrix) -> Option<CostMatrix<'a>> + 'a,
-        T: HasPosition,
+        T: ?Sized + HasPosition,
     {
         let self_room = game::rooms::get(&self.room_name()).unwrap();
         self_room.find_path(self, target, opts)
@@ -110,14 +110,14 @@ impl RoomPosition {
 
     pub fn in_range_to<T>(&self, target: &T, range: u32) -> bool
     where
-        T: HasPosition,
+        T: ?Sized + HasPosition,
     {
         js_unwrap!(@{self.as_ref()}.inRangeTo(@{&target.pos().0}, @{range}))
     }
 
     pub fn is_equal_to<T>(&self, target: &T) -> bool
     where
-        T: HasPosition,
+        T: ?Sized + HasPosition,
     {
         js_unwrap!(@{self.as_ref()}.isEqualTo(@{&target.pos().0}))
     }
@@ -128,7 +128,7 @@ impl RoomPosition {
 
     pub fn is_near_to<T>(&self, target: &T) -> bool
     where
-        T: HasPosition,
+        T: ?Sized + HasPosition,
     {
         js_unwrap!(@{self.as_ref()}.isNearTo(@{&target.pos().0}))
     }

--- a/screeps-game-api/src/objects/mod.rs
+++ b/screeps-game-api/src/objects/mod.rs
@@ -417,7 +417,6 @@ unsafe impl Withdrawable for Tombstone {}
 
 unsafe impl Attackable for Creep {}
 unsafe impl Attackable for OwnedStructure {}
-unsafe impl Attackable for Structure {}
 unsafe impl Attackable for StructureContainer {}
 unsafe impl Attackable for StructureExtension {}
 unsafe impl Attackable for StructureExtractor {}

--- a/screeps-game-api/src/pathfinder.rs
+++ b/screeps-game-api/src/pathfinder.rs
@@ -304,8 +304,8 @@ pub fn search<'a, O, G, F>(
     opts: SearchOptions<'a, F>,
 ) -> SearchResults
 where
-    O: HasPosition,
-    G: HasPosition,
+    O: ?Sized + HasPosition,
+    G: ?Sized + HasPosition,
     F: Fn(String) -> CostMatrix<'a> + 'a,
 {
     let pos = goal.pos();


### PR DESCRIPTION
Closes #123. Fixes #118.

This is a few things in one PR, but I think they go together. This:

- adds `?Sized` bounds to a number of Creep, Room and RoomPosition methods which take `&T` for `T: SomeTrait`. `?Sized` allows usages of `&dyn Trait` here.
- adds more documentation to `Structure` on using `as_*` methods.
- Removes `impl Attackable for Structure` as this is is incorrect.

Explicitly does not fix `StructurePortal`, nor `OwnedStructure`, as we have more problems there.