### PR TITLE
Release cargo-screeps 0.3.0.

### DIFF
--- a/cargo-screeps/Cargo.toml
+++ b/cargo-screeps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-screeps"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["David Ross <daboross@daboross.net>"]
 documentation = "https://github.com/daboross/screeps-in-rust-via-wasm/cargo-screeps/"
 include = [


### PR DESCRIPTION
- Update to reqwest 0.9
- Change default WASM module initialization and allow projects to override module initialization via configuration (see [docs/initialiation-header.md](https://github.com/daboross/screeps-in-rust-via-wasm/blob/master/cargo-screeps/docs/initialization-header.md))