### PR TITLE
Fix Room::find panics on the live environment

### DIFF
--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -94,7 +94,7 @@ impl Room {
     where
         T: FindConstant,
     {
-        js_unwrap_ref!(@{self.as_ref()}.find(@{ty.find_code()}))
+        js_unwrap_ref!(Object.values(@{self.as_ref()}.find(@{ty.find_code()})))
     }
 
     pub fn find_exit_to(&self, room: &Room) -> Result<Exit, ReturnCode> {


### PR DESCRIPTION
Hey!

I encountered an issue where `Room::find` would panic when playing on the live environment.
it works fine in simulation, but on the live world I always encounter a panic.
Here's an example stack trace
```
[8:18:11 PM][shard3]Encountered a panic!
[8:18:11 PM][shard3]Panic error message: js_unwrap_ref at 97 in C:\Dev\screeps-in-rust-via-wasm\screeps-game-api\src\objects\impls\room.rs: Custom("reference is of a different type")
[8:18:11 PM][shard3]Panic location: src/libcore/result.rs:1009
[8:18:11 PM][shard3]caught exception: RuntimeError: unreachable
[8:18:11 PM][shard3]stack trace: RuntimeError: unreachable
    at rust_panic (wasm-function[613]:1)
    at _ZN3std9panicking20rust_panic_with_hook17h869ce4541d4e3554E (wasm-function[451]:295)
    at _ZN3std9panicking18continue_panic_fmt17h0ad726c0b188da91E (wasm-function[629]:75)
    at rust_begin_unwind (wasm-function[662]:3)
    at _ZN4core9panicking9panic_fmt17h4d67173bc68f6d5aE (wasm-function[438]:70)
    at _ZN4core6result13unwrap_failed17hfc6bc97b52ed5f63E (wasm-function[288]:130)
    at _ZN5xenos6creeps9harvester15attempt_harvest17h865640d46b5bd9d4E (wasm-function[119]:4503)
    at _ZN5xenos6creeps9harvester3run28_$u7b$$u7b$closure$u7d$$u7d$17h300928efa798c577E (wasm-function[321]:10)
    at _ZN70_$LT$xenos..bt..Control$LT$$u27$a$GT$$u20$as$u20$xenos..bt..BtNode$GT$4tick17h631da085a125a2dbE (wasm-function[115]:1096)
    at _ZN5xenos6creeps9harvester3run28_$u7b$$u7b$closure$u7d$$u7d$17h80e90cff34d67169E (wasm-function[280]:7)
```

Calling `Object.values` on the JavaScript results before returning seems to fix this problem.