### PR TITLE
Add support for using Screeps auth tokens instead of username/password

### DIFF
--- a/cargo-screeps/README.md
+++ b/cargo-screeps/README.md
@@ -73,10 +73,11 @@ Options for the `upload` deploy mode.
 
 This section is required to use `cargo screeps upload`.
 
+- `auth_token`: an auth token for your Screeps account
 - `username`: your Screeps username or email
 - `password`: your Screeps password
 
-  For private servers set a password using [screepsmod-auth].
+  Either an auth_token or your username/password can be supplied. When both are set the auth token is used. For private servers set a password using [screepsmod-auth].
 - `branch`: the branch on the server to upload files to
 - `ptr`: if true, upload to the "ptr" realm
 - `hostname`: the hostname to upload to

--- a/cargo-screeps/src/config.rs
+++ b/cargo-screeps/src/config.rs
@@ -73,7 +73,7 @@ pub struct UploadConfiguration {
 #[derive(Clone, Debug)]
 pub enum Authentication {
     Token(String),
-    Basic {username: String, password: String},
+    Basic { username: String, password: String },
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -131,7 +131,10 @@ impl UploadConfiguration {
         let authentication = if auth_token.is_some() {
             Authentication::Token(auth_token.unwrap())
         } else if username.is_some() && password.is_some() {
-            Authentication::Basic {username: username.unwrap(), password: password.unwrap()}
+            Authentication::Basic {
+                username: username.unwrap(),
+                password: password.unwrap(),
+            }
         } else {
             bail!("either auth_token or username/password must be set in the [upload] section of the configuration");
         };

--- a/cargo-screeps/src/config.rs
+++ b/cargo-screeps/src/config.rs
@@ -39,8 +39,9 @@ impl BuildConfiguration {
 
 #[derive(Clone, Debug, Deserialize)]
 struct FileUploadConfiguration {
-    username: String,
-    password: String,
+    auth_token: Option<String>,
+    username: Option<String>,
+    password: Option<String>,
     branch: String,
     #[serde(default = "default_hostname")]
     hostname: String,
@@ -61,8 +62,9 @@ fn default_ptr() -> bool {
 
 #[derive(Clone, Debug)]
 pub struct UploadConfiguration {
-    pub username: String,
-    pub password: String,
+    pub auth_token: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<String>,
     pub hostname: String,
     pub branch: String,
     pub ssl: bool,
@@ -109,6 +111,7 @@ pub struct Configuration {
 impl UploadConfiguration {
     fn new(config: FileUploadConfiguration) -> Result<UploadConfiguration, failure::Error> {
         let FileUploadConfiguration {
+            auth_token,
             username,
             password,
             branch,
@@ -122,6 +125,7 @@ impl UploadConfiguration {
         let port = port.unwrap_or_else(|| if ssl { 443 } else { 80 });
 
         Ok(UploadConfiguration {
+            auth_token,
             username,
             password,
             branch,

--- a/cargo-screeps/src/upload.rs
+++ b/cargo-screeps/src/upload.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fs, io::Read, path::Path};
 
 use {base64, failure, reqwest, serde_json};
 
-use config::{Configuration, UploadConfiguration};
+use config::{Authentication, Configuration, UploadConfiguration};
 
 pub fn upload(root: &Path, config: &Configuration) -> Result<(), failure::Error> {
     let upload_config = config.upload.as_ref().ok_or_else(|| {
@@ -60,7 +60,7 @@ pub fn upload(root: &Path, config: &Configuration) -> Result<(), failure::Error>
         branch: String,
     }
 
-    let mut response = authorize(client.post(&url), upload_config)?
+    let mut response = authorize(client.post(&url), upload_config)
         .json(&RequestData {
             modules: files,
             branch: upload_config.branch.clone(),
@@ -96,18 +96,19 @@ pub fn upload(root: &Path, config: &Configuration) -> Result<(), failure::Error>
 fn authorize(
     request: reqwest::RequestBuilder,
     upload_config: &UploadConfiguration,
-) -> Result<reqwest::RequestBuilder, failure::Error> {
-    if upload_config.auth_token.is_some() {
-        Ok(request.header(
-            "X-Token",
-            upload_config.auth_token.as_ref().unwrap().as_str(),
-        ))
-    } else if upload_config.username.is_some() && upload_config.password.is_some() {
-        Ok(request.basic_auth(
-            upload_config.username.as_ref().unwrap(),
-            upload_config.password.as_ref(),
-        ))
-    } else {
-        bail!("could not authorize request. must set auth_token or username/password in [upload] config");
+) -> reqwest::RequestBuilder {
+    match upload_config.authentication {
+        Authentication::Token(ref token) => {
+            request.header(
+                "X-Token",
+                token.as_str(),
+            )
+        },
+        Authentication::Basic {ref username, ref password} => {
+            request.basic_auth(
+                username,
+                Some(password),
+            )
+        },
     }
 }

--- a/screeps-defaults.toml
+++ b/screeps-defaults.toml
@@ -1,9 +1,10 @@
 default_deploy_mode = "upload"
 
 [upload]
-username = "your username or email"
-password = "your password"
+auth_token = "your auth token"
 branch = "default"
+# username = "your username or email"
+# password = "your password"
 # ptr = false
 # hostname = "screeps.com"
 # ssl = true


### PR DESCRIPTION
Add support for optionally supplying a Screeps authentication token for upload purposes.