### PR TITLE
update prefix generated by cargo web

### DIFF
--- a/cargo-screeps/src/build.rs
+++ b/cargo-screeps/src/build.rs
@@ -140,11 +140,11 @@ if( typeof Rust === "undefined" ) {
     } else {
         Rust.XXX = factory();
     }
-}   ( this, function() {
+}( this, function() {
     return (function( module_factory ) {
         var instance = module_factory();
 
-        if( typeof window === "undefined" && typeof process === "object" ) {
+        if( typeof process === "object" && typeof process.versions === "object" && typeof process.versions.node === "string" ) {
             var fs = require( "fs" );
             var path = require( "path" );
             var wasm_path = path.join( __dirname, "XXX.wasm" );


### PR DESCRIPTION
This fix error created by new cargo web generation : 
```
error: 'cargo web' generated unexpected JS prefix! This means it's updated without 'cargo screeps' also having updated. Please report this issue to https://github.com/daboross/screeps-in-rust-via-wasm/issues and include the first ~30 lines of /home/babariviere/projects/screeps/target/wasm32-unknown-unknown/release/screeps-bot.js
```