### PR TITLE
Release cargo-screeps 0.3.2

### DIFF
--- a/cargo-screeps/Cargo.toml
+++ b/cargo-screeps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-screeps"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["David Ross <daboross@daboross.net>"]
 documentation = "https://github.com/daboross/screeps-in-rust-via-wasm/cargo-screeps/"
 include = [


### PR DESCRIPTION
Release cargo-screeps version 0.3.2

- Add support for using Screeps auth tokens instead of username/password ([#137], thanks [@npfund]!)
- Support cargo-web version 0.6.25 (#138, thanks [@babariviere]!)

[#137]: https://github.com/daboross/screeps-in-rust-via-wasm/pull/137
[#138]: https://github.com/daboross/screeps-in-rust-via-wasm/pull/138
[@babariviere]: https://github.com/babariviere
[@npfund]: https://github.com/npfund

Fixes #140.