### PR TITLE
Use 'dyn Trait' in screeps-game-api

### DIFF
--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -201,9 +201,9 @@ pub mod map {
             FR_CALLBACK.with(|callback| callback(room_name, from_room_name))
         }
 
-        let callback_type_erased: Box<Fn(String, String) -> f64> = Box::new(route_callback);
+        let callback_type_erased: Box<dyn Fn(String, String) -> f64> = Box::new(route_callback);
 
-        let callback_lifetime_erased: Box<Fn(String, String) -> f64 + 'static> =
+        let callback_lifetime_erased: Box<dyn Fn(String, String) -> f64 + 'static> =
             unsafe { mem::transmute(callback_type_erased) };
 
         FR_CALLBACK.set(&callback_lifetime_erased, || {
@@ -218,7 +218,7 @@ pub mod map {
         parse_find_route_returned_value(v)
     }
 
-    scoped_thread_local!(static FR_CALLBACK: Box<(Fn(String, String) -> f64)>);
+    scoped_thread_local!(static FR_CALLBACK: Box<(dyn Fn(String, String) -> f64)>);
 
     pub fn find_route_with_callback(
         from_room: &str,
@@ -230,9 +230,9 @@ pub mod map {
             FR_CALLBACK.with(|callback| callback(room_name, from_room_name))
         }
 
-        let callback_type_erased: Box<Fn(String, String) -> f64> = Box::new(route_callback);
+        let callback_type_erased: Box<dyn Fn(String, String) -> f64> = Box::new(route_callback);
 
-        let callback_lifetime_erased: Box<Fn(String, String) -> f64 + 'static> =
+        let callback_lifetime_erased: Box<dyn Fn(String, String) -> f64 + 'static> =
             unsafe { mem::transmute(callback_type_erased) };
 
         FR_CALLBACK.set(&callback_lifetime_erased, || {

--- a/screeps-game-api/src/objects/impls/creep.rs
+++ b/screeps-game-api/src/objects/impls/creep.rs
@@ -15,7 +15,7 @@ use {
 
 use super::room::Step;
 
-scoped_thread_local!(static COST_CALLBACK: Box<Fn(String, Reference) -> Option<Reference>>);
+scoped_thread_local!(static COST_CALLBACK: Box<dyn Fn(String, Reference) -> Option<Reference>>);
 
 impl Creep {
     pub fn body(&self) -> Vec<Bodypart> {
@@ -147,7 +147,7 @@ impl Creep {
 
         // Type erased and boxed callback: no longer a type specific to the closure passed in,
         // now unified as Box<Fn>
-        let callback_type_erased: Box<Fn(String, Reference) -> Option<Reference> + 'a> =
+        let callback_type_erased: Box<dyn Fn(String, Reference) -> Option<Reference> + 'a> =
             Box::new(callback_boxed);
 
         // Overwrite lifetime of box inside closure so it can be stuck in scoped_thread_local storage:
@@ -155,7 +155,7 @@ impl Creep {
         // be entirely safe because we're only sticking it in scoped storage and we control the only use
         // of it, but it's still necessary because "some lifetime above the current scope but otherwise
         // unknown" is not a valid lifetime to have PF_CALLBACK have.
-        let callback_lifetime_erased: Box<Fn(String, Reference) -> Option<Reference> + 'static> =
+        let callback_lifetime_erased: Box<dyn Fn(String, Reference) -> Option<Reference> + 'static> =
             unsafe { mem::transmute(callback_type_erased) };
 
         // Store callback_lifetime_erased in COST_CALLBACK for the duration of the PathFinder call and

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -32,7 +32,7 @@ simple_accessors! {
     // todo: visual
 }
 
-scoped_thread_local!(static COST_CALLBACK: &'static Fn(String, Reference) -> Option<Reference>);
+scoped_thread_local!(static COST_CALLBACK: &'static dyn Fn(String, Reference) -> Option<Reference>);
 
 impl Room {
     pub fn serialize_path(&self, path: &[Step]) -> String {
@@ -171,7 +171,7 @@ impl Room {
 
         // Type erased and boxed callback: no longer a type specific to the closure passed in,
         // now unified as &Fn
-        let callback_type_erased: &(Fn(String, Reference) -> Option<Reference> + 'a) =
+        let callback_type_erased: &(dyn Fn(String, Reference) -> Option<Reference> + 'a) =
             &callback_boxed;
 
         // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
@@ -179,7 +179,7 @@ impl Room {
         // we're only sticking it in scoped storage and we control the only use of it, but it's
         // still necessary because "some lifetime above the  current scope but otherwise unknown" is
         // not a valid lifetime to have PF_CALLBACK have.
-        let callback_lifetime_erased: &'static Fn(String, Reference) -> Option<Reference> =
+        let callback_lifetime_erased: &'static dyn Fn(String, Reference) -> Option<Reference> =
             unsafe { mem::transmute(callback_type_erased) };
 
         let FindOptions {

--- a/screeps-game-api/src/pathfinder.rs
+++ b/screeps-game-api/src/pathfinder.rs
@@ -335,7 +335,7 @@ where
     search_real(&origin.pos(), &goals_js, opts)
 }
 
-scoped_thread_local!(static PF_CALLBACK: &'static Fn(String) -> Reference);
+scoped_thread_local!(static PF_CALLBACK: &'static dyn Fn(String) -> Reference);
 
 fn search_real<'a, F>(
     origin: &RoomPosition,
@@ -361,14 +361,14 @@ where
 
     // Type erased and boxed callback: no longer a type specific to the closure passed in,
     // now unified as &Fn
-    let callback_type_erased: &(Fn(String) -> Reference + 'a) = &callback_unboxed;
+    let callback_type_erased: &(dyn Fn(String) -> Reference + 'a) = &callback_unboxed;
 
     // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
     // storage: it's now pretending to be static data. This should be entirely safe because we're
     // only sticking it in scoped storage and we control the only use of it, but it's still
     // necessary because "some lifetime above the current scope but otherwise unknown" is not a
     // valid lifetime to have PF_CALLBACK have.
-    let callback_lifetime_erased: &'static Fn(String) -> Reference =
+    let callback_lifetime_erased: &'static dyn Fn(String) -> Reference =
         unsafe { mem::transmute(callback_type_erased) };
 
     let SearchOptions {


### PR DESCRIPTION
This is a purely stylistic change, using the newer 'dyn Trait' syntax rather than the semi-deprecated syntax of leaving out 'dyn'.