### PR TITLE
Implemented Into() for numeric tuple types on RoomPosition

### DIFF
--- a/screeps-game-api/src/objects/impls/room_position.rs
+++ b/screeps-game-api/src/objects/impls/room_position.rs
@@ -24,6 +24,14 @@ impl RoomPosition {
         js_unwrap!(@{self.as_ref()}.y)
     }
 
+    pub fn coords(&self) -> (u32, u32) {
+        (self.x(), self.y())
+    }
+
+    pub fn coords_signed(&self) -> (i32, i32) {
+        (self.x() as i32, self.y() as i32)
+    }
+
     pub fn room_name(&self) -> String {
         js_unwrap!(@{self.as_ref()}.roomName)
     }
@@ -160,3 +168,51 @@ impl<T: HasPosition> PartialEq<T> for RoomPosition {
 }
 
 impl Eq for RoomPosition {}
+
+impl Into<(u8, u8)> for RoomPosition {
+    fn into(self) -> (u8, u8) {
+        (self.x() as u8, self.y() as u8)
+    }
+}
+
+impl Into<(u16, u16)> for RoomPosition {
+    fn into(self) -> (u16, u16) {
+        (self.x() as u16, self.y() as u16)
+    }
+}
+
+impl Into<(u32, u32)> for RoomPosition {
+    fn into(self) -> (u32, u32) {
+        (self.x(), self.y())
+    }
+}
+
+impl Into<(u64, u64)> for RoomPosition {
+    fn into(self) -> (u64, u64) {
+        (self.x() as u64, self.y() as u64)
+    }
+}
+
+impl Into<(i8, i8)> for RoomPosition {
+    fn into(self) -> (i8, i8) {
+        (self.x() as i8, self.y() as i8)
+    }
+}
+
+impl Into<(i16, i16)> for RoomPosition {
+    fn into(self) -> (i16, i16) {
+        (self.x() as i16, self.y() as i16)
+    }
+}
+
+impl Into<(i32, i32)> for RoomPosition {
+    fn into(self) -> (i32, i32) {
+        (self.x() as i32, self.y() as i32)
+    }
+}
+
+impl Into<(i64, i64)> for RoomPosition {
+    fn into(self) -> (i64, i64) {
+        (self.x() as i64, self.y() as i64)
+    }
+}


### PR DESCRIPTION
This adds `Into` implementations for `RoomPosition` for pairs of `u8` through `u64` and `i8` through `i64`.

This also adds `coords() -> (u32, u32)` and `coords_signed() -> (i32, i32)` to `impl RoomPosition`.