### PR TITLE
Add "no_return" attribute to js! invocations with no return value

### DIFF
--- a/screeps-game-api/src/game.rs
+++ b/screeps-game-api/src/game.rs
@@ -520,5 +520,7 @@ pub fn get_object_erased(id: &str) -> Option<RoomObject> {
 }
 
 pub fn notify(message: &str, group_interval: Option<u32>) {
-    js! {Game.notify(@{message}, @{group_interval.unwrap_or(0)})};
+    js! { @(no_return)
+        Game.notify(@{message}, @{group_interval.unwrap_or(0)});
+    }
 }

--- a/screeps-game-api/src/memory.rs
+++ b/screeps-game-api/src/memory.rs
@@ -196,7 +196,7 @@ impl MemoryReference {
     }
 
     pub fn del(&self, key: &str) {
-        js! {
+        js! { @(no_return)
             (@{self.as_ref()})[@{key}] = undefined;
         }
     }
@@ -231,7 +231,7 @@ impl MemoryReference {
     where
         T: JsSerialize,
     {
-        js! {
+        js! { @(no_return)
             (@{self.as_ref()})[@{key}] = @{value};
         }
     }
@@ -240,7 +240,7 @@ impl MemoryReference {
     where
         T: JsSerialize,
     {
-        js! {
+        js! { @(no_return)
             _.set(@{self.as_ref()}, @{path}, @{value});
         }
     }

--- a/screeps-game-api/src/objects/impls/flag.rs
+++ b/screeps-game-api/src/objects/impls/flag.rs
@@ -12,13 +12,17 @@ simple_accessors! {
 
 impl Flag {
     pub fn remove(&self) {
-        js! {@{self.as_ref()}.remove();};
+        js! { @(no_return)
+            @{self.as_ref()}.remove();
+        }
     }
 
     pub fn set_color(&self, color: Color, secondary_color: Option<Color>) {
         match secondary_color {
-            None => js! {@{self.as_ref()}.setColor(@{u32::from(color)});},
-            Some(sec_color) => js! {
+            None => js! { @(no_return)
+                @{self.as_ref()}.setColor(@{u32::from(color)});
+            },
+            Some(sec_color) => js! { @(no_return)
                 @{self.as_ref()}.setColor(
                     @{u32::from(color)},
                     @{u32::from(sec_color)},
@@ -29,10 +33,14 @@ impl Flag {
 
     pub fn set_position<T: HasPosition>(&self, pos: T) {
         let room_pos = pos.pos();
-        js! {@{self.as_ref()}.setPosition(@{room_pos.as_ref()});};
+        js! { @(no_return)
+            @{self.as_ref()}.setPosition(@{room_pos.as_ref()});
+        }
     }
 
     pub fn set_position_xy(&self, x: u32, y: u32) {
-        js! {@{self.as_ref()}.setPosition(@{x}, @{y});};
+        js! { @(no_return)
+            @{self.as_ref()}.setPosition(@{x}, @{y});
+        }
     }
 }

--- a/screeps-game-api/src/objects/impls/structure_spawn.rs
+++ b/screeps-game-api/src/objects/impls/structure_spawn.rs
@@ -40,13 +40,19 @@ impl StructureSpawn {
         let js_opts = js!(return {dryRun: @{opts.dry_run}};);
 
         if let Some(ref mem) = opts.memory {
-            js!(@{&js_opts}.memory = @{mem.as_ref()};);
+            js! { @(no_return)
+                @{&js_opts}.memory = @{mem.as_ref()};
+            }
         }
         if !opts.energy_structures.is_empty() {
-            js!(@{&js_opts}.energyStructures = @{&opts.energy_structures};);
+            js! { @(no_return)
+                @{&js_opts}.energyStructures = @{&opts.energy_structures};
+            }
         }
         if !opts.directions.is_empty() {
-            js!(@{&js_opts}.directions = @{&opts.directions};);
+            js! { @(no_return)
+                @{&js_opts}.directions = @{&opts.directions};
+            }
         }
         (js! {
             var body = (@{body_ints}).map(__part_num_to_str);

--- a/screeps-game-api/src/raw_memory.rs
+++ b/screeps-game-api/src/raw_memory.rs
@@ -18,7 +18,7 @@ pub fn set_active_segments(ids: &[u32]) {
         ids.len() <= 10,
         "can't set more than 10 active segments at a time"
     );
-    js! {
+    js! { @(no_return)
         RawMemory.setActiveSegments(@{ids});
     }
 }
@@ -28,7 +28,7 @@ get_from_js!(get_segment(id: u32) -> {
 } -> Option<String>);
 
 pub fn set_segment(id: u32, data: &str) {
-    js! {
+    js! { @(no_return)
         RawMemory.segments[@{id}] = @{data};
     }
 }
@@ -46,23 +46,29 @@ get_from_js!(get_foreign_segment -> {
 ///
 pub fn set_active_foreign_segment(username: &str, id: Option<u32>) {
     if username == "" {
-        js! { RawMemory.setActiveForeignSegment(null); }
+        js! { @(no_return)
+            RawMemory.setActiveForeignSegment(null);
+        }
     } else {
         match id {
-            Some(id) => js! { RawMemory.setActiveForeignSegment(@{username}, @{id}); },
-            None => js! { RawMemory.setActiveForeignSegment(@{username}); },
+            Some(id) => js! { @(no_return)
+                RawMemory.setActiveForeignSegment(@{username}, @{id});
+            },
+            None => js! { @(no_return)
+                RawMemory.setActiveForeignSegment(@{username});
+            },
         };
     };
 }
 
 pub fn set_default_public_segment(id: u32) {
-    js! {
+    js! { @(no_return)
         RawMemory.setDefaultPublicSegment(@{id});
     }
 }
 
 pub fn set_public_segments(ids: &[u32]) {
-    js! {
+    js! { @(no_return)
         RawMemory.setPublicSegments(@{ids});
     }
 }
@@ -70,7 +76,7 @@ pub fn set_public_segments(ids: &[u32]) {
 get_from_js!(get -> {RawMemory.get()} -> String);
 
 pub fn set(value: &str) {
-    js! {
+    js! { @(no_return)
         RawMemory.set(@{value});
     }
 }


### PR DESCRIPTION
If we don't need a return value, this "slightly improves performance". Another thought is that if every js! invocation either has a `return` or `(no_return)`, it should avoid issues like #152. 

Found this annotation a while ago looking through the `stdweb` codebase - it's documented at https://docs.rs/stdweb/0.4.17/stdweb/macro.js.html#no-return.
