### PR TITLE
Fix flag creation result interpretation.

### DIFF
--- a/screeps-game-api/src/constants.rs
+++ b/screeps-game-api/src/constants.rs
@@ -4,7 +4,7 @@
 //! <https://github.com/screeps/common/commits/master/lib/constants.js>.
 //!
 //! [the game constants]: https://github.com/screeps/common/blob/master/lib/constants.js
-use stdweb::{Reference, Value};
+use stdweb::{Number, Reference, Value};
 
 use {
     objects::RoomObject,
@@ -53,6 +53,18 @@ impl ReturnCode {
 impl TryFrom<Value> for ReturnCode {
     type Error = ConversionError;
     fn try_from(v: Value) -> Result<Self, Self::Error> {
+        use num_traits::FromPrimitive;
+        let x: i32 = v.try_into()?;
+        Ok(Self::from_i32(x).unwrap_or_else(|| {
+            error!("encountered a return code we don't know: {}", x);
+            ReturnCode::Other
+        }))
+    }
+}
+
+impl TryFrom<Number> for ReturnCode {
+    type Error = ConversionError;
+    fn try_from(v: Number) -> Result<Self, Self::Error> {
         use num_traits::FromPrimitive;
         let x: i32 = v.try_into()?;
         Ok(Self::from_i32(x).unwrap_or_else(|| {

--- a/screeps-game-api/src/objects/impls/flag.rs
+++ b/screeps-game-api/src/objects/impls/flag.rs
@@ -1,6 +1,9 @@
+use stdweb::Value;
+
 use {
-    constants::Color,
+    constants::{Color, ReturnCode},
     objects::{Flag, HasPosition},
+    traits::TryFrom,
 };
 
 simple_accessors! {
@@ -11,6 +14,20 @@ simple_accessors! {
 }
 
 impl Flag {
+    /// Useful method for constructing Flag from the result of `RoomPosition.createFlag`
+    /// or `Room.createFlag`.
+    ///
+    /// String names are mapped to Ok(Ok(s)), return codes are mapped to Ok(Err(e)), other
+    /// unknown inputs are mapped to Err(e).
+    pub(crate) fn interpret_creation_ret_value(
+        value: Value,
+    ) -> Result<Result<String, ReturnCode>, crate::ConversionError> {
+        match value {
+            Value::Number(num) => Ok(Err(ReturnCode::try_from(num)?)),
+            other => String::try_from(other).map(Ok),
+        }
+    }
+
     pub fn remove(&self) {
         js! { @(no_return)
             @{self.as_ref()}.remove();

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -77,17 +77,20 @@ impl Room {
         name: &str,
         main_color: Color,
         secondary_color: Color,
-    ) -> ReturnCode
+    ) -> Result<String, ReturnCode>
     where
         T: ?Sized + HasPosition,
     {
         let pos = at.pos();
-        js_unwrap!(@{self.as_ref()}.createFlag(
-            @{pos.as_ref()},
-            @{name},
-            @{main_color as u32},
-            @{secondary_color as u32}
-        ))
+        Flag::interpret_creation_ret_value(js! {
+            return @{self.as_ref()}.createFlag(
+                @{pos.as_ref()},
+                @{name},
+                @{main_color as u32},
+                @{secondary_color as u32}
+            );
+        })
+        .expect("expected Room.createFlag to return ReturnCode or String name")
     }
 
     pub fn find<T>(&self, ty: T) -> Vec<T::Item>


### PR DESCRIPTION
I've tested this locally. Would be nice if we had unit tests set up with the screeps server, but that's a whole deal.

Fixes #115.

I'm certain `Flag` isn't _really_ where `interpret_creation_ret_value` should go, but it does relate to flags. Might be worth moving small code reuse functions like this to a util(s) module in the future?