### PR TITLE
Add a method to stop tracking a RawMemory segment using `drop_segment`.

### DIFF
--- a/screeps-game-api/src/raw_memory.rs
+++ b/screeps-game-api/src/raw_memory.rs
@@ -33,6 +33,12 @@ pub fn set_segment(id: u32, data: &str) {
     }
 }
 
+pub fn drop_segment(id: u32) {
+    js! { @(no_return)
+        delete RawMemory.segments[@{id}];
+    }
+}
+
 get_from_js!(get_foreign_segment -> {
     RawMemory.foreignSegment
 } -> ForeignSegment);

--- a/screeps-game-api/src/raw_memory.rs
+++ b/screeps-game-api/src/raw_memory.rs
@@ -33,6 +33,11 @@ pub fn set_segment(id: u32, data: &str) {
     }
 }
 
+/// This drops the reference to a segment; it doesn't affect the content of the segment.
+///
+/// This is the equivalent of doing `delete RawMemory.segments[id]`. Again, this only
+/// deletes the local view of the segment, not the serialized one. It may be used to
+/// `set_segment` a new segment that wasn't part of the original 10 active segments.
 pub fn drop_segment(id: u32) {
     js! { @(no_return)
         delete RawMemory.segments[@{id}];


### PR DESCRIPTION
It turns out that the Screeps driver doesn't check which segments are written at the end of a tick, so long as there are only 10 segments that are written to.

This leads to a bot being able to "touch" 20 segments in a tick: 
- 10 to be read at the beginning of the tick (from the `setActiveSegments`)
- 10 to be written at the end of the tick (in `RawMemory.segments`)

However, no checks is done to verify that the written segments are part of the active segments.
Thus, by adding a way to `drop_segment` (this PR) (deleting it from `RawMemory.segments`), it can make space to write to a different segment.

Note: deleting `RawMemory.segments[k]` is local only, it doesn't touch the actual data in the segment.