### PR TITLE
Make many StructureController properties Option<u32>.

### DIFF
--- a/screeps-game-api/src/objects/impls/structure_controller.rs
+++ b/screeps-game-api/src/objects/impls/structure_controller.rs
@@ -5,13 +5,13 @@ use {constants::ReturnCode, objects::StructureController};
 simple_accessors! {
     StructureController;
     (level -> level -> u32),
-    (progress -> progress -> u32),
-    (progress_total -> progressTotal -> u32),
-    (safe_mode -> safeMode -> u32),
+    (progress -> progress -> Option<u32>),
+    (progress_total -> progressTotal -> Option<u32>),
+    (safe_mode -> safeMode -> Option<u32>),
     (safe_mode_available -> safeModeAvailable -> u32),
-    (safe_mode_cooldown -> safeModeCooldown -> u32),
+    (safe_mode_cooldown -> safeModeCooldown -> Option<u32>),
     (ticks_to_downgrade -> ticksToDowngrade -> u32),
-    (upgrade_blocked -> upgradeBlocked -> u32)
+    (upgrade_blocked -> upgradeBlocked -> Option<u32>)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
These properties seem to be guaranteed undefined if they're not applicable.

Found this trying to use them, then found the complete list of sometimes-undefined properties by checking accessor code at https://github.com/screeps/engine/blob/a4e431c9ee33dcc55c04f3adc479145c210c73fd/src/game/structures.js#L263-L268.