### PR TITLE
Add interface to InterShardMemory.

### DIFF
--- a/screeps-game-api/src/inter_shard_memory.rs
+++ b/screeps-game-api/src/inter_shard_memory.rs
@@ -13,15 +13,13 @@
 
 /// Returns the string contents of the current shard's data.
 pub fn get_local() -> String {
-    js_unwrap! {
-        InterShardMemory.getLocal()
-    }
+    js_unwrap!(InterShardMemory.getLocal())
 }
 
 /// Replace the current shard's data with the new value.
 pub fn set_local(value: &str) {
-    js! { @(no_return)
-        InterShardMemory.setLocal(@{value})
+    js! {
+        InterShardMemory.setLocal(@{value});
     }
 }
 
@@ -29,7 +27,5 @@ pub fn set_local(value: &str) {
 ///
 /// Consider using [`game::cpu::shard_limits`] to retrieve shard names.
 pub fn get_remote(shard: &str) -> String {
-    js_unwrap! {
-        InterShardMemory.getRemote(shard)
-    }
+    js_unwrap!(InterShardMemory.getRemote(shard))
 }

--- a/screeps-game-api/src/inter_shard_memory.rs
+++ b/screeps-game-api/src/inter_shard_memory.rs
@@ -1,0 +1,35 @@
+//! `inter_shard_memory` provides an interface for communciating between shards.
+//!
+//! Quoted from https://docs.screeps.com/api/#InterShardMemory:
+//!
+//! InterShardMemory object provides an interface for communicating between shards. Your script is executed separatedly
+//! on each shard, and their Memory objects are isolated from each other. In order to pass messages and data between
+//! shards, you need to use InterShardMemory instead.
+//!
+//! Every shard can have its own data string that can be accessed by all other shards. A shard can write only to its
+//! own data, other shards' data is read-only.
+//!
+//! This data has nothing to do with Memory contents, it's a separate data container.
+
+/// Returns the string contents of the current shard's data.
+pub fn get_local() -> String {
+    js_unwrap! {
+        InterShardMemory.getLocal()
+    }
+}
+
+/// Replace the current shard's data with the new value.
+pub fn set_local(value: &str) {
+    js! { @(no_return)
+        InterShardMemory.setLocal(@{value})
+    }
+}
+
+/// Returns the string contents of another shard's data.
+///
+/// Consider using [`game::cpu::shard_limits`] to retrieve shard names.
+pub fn get_remote(shard: &str) -> String {
+    js_unwrap! {
+        InterShardMemory.getRemote(shard)
+    }
+}

--- a/screeps-game-api/src/inter_shard_memory.rs
+++ b/screeps-game-api/src/inter_shard_memory.rs
@@ -10,6 +10,7 @@
 //! own data, other shards' data is read-only.
 //!
 //! This data has nothing to do with Memory contents, it's a separate data container.
+use crate::macros::*;
 
 /// Returns the string contents of the current shard's data.
 pub fn get_local() -> String {

--- a/screeps-game-api/src/inter_shard_memory.rs
+++ b/screeps-game-api/src/inter_shard_memory.rs
@@ -28,5 +28,5 @@ pub fn set_local(value: &str) {
 ///
 /// Consider using [`game::cpu::shard_limits`] to retrieve shard names.
 pub fn get_remote(shard: &str) -> String {
-    js_unwrap!(InterShardMemory.getRemote(shard))
+    js_unwrap!(InterShardMemory.getRemote(@{shard}))
 }

--- a/screeps-game-api/src/lib.rs
+++ b/screeps-game-api/src/lib.rs
@@ -24,13 +24,13 @@ pub mod macros;
 
 pub mod constants;
 pub mod game;
+pub mod inter_shard_memory;
 pub mod js_collections;
 pub mod memory;
 pub mod objects;
 pub mod pathfinder;
 mod positions;
 pub mod raw_memory;
-pub mod inter_shard_memory;
 pub mod traits;
 
 pub use stdweb::private::ConversionError;

--- a/screeps-game-api/src/lib.rs
+++ b/screeps-game-api/src/lib.rs
@@ -30,6 +30,7 @@ pub mod objects;
 pub mod pathfinder;
 mod positions;
 pub mod raw_memory;
+pub mod inter_shard_memory;
 pub mod traits;
 
 pub use stdweb::private::ConversionError;


### PR DESCRIPTION
I don't think we ever added an interface for the old `RawMemory.interShardSegment`. But in any case, as of https://blog.screeps.com/2019/03/power-era/, this is the new API.

I've opted to copy the documentation from https://docs.screeps.com/api/#Game rather than link it, since that seems more friendly. Not sure if it's a better strategy overall though?