### PR TITLE
Improve LocalRoomPosition's Serialize/Deserialize impls and add js_serializable! call

### DIFF
--- a/screeps-game-api/src/memory.rs
+++ b/screeps-game-api/src/memory.rs
@@ -210,6 +210,31 @@ impl MemoryReference {
 
     /// Gets a custom type. Will return `None` if `null` or `undefined`, and
     /// `Err` if incorrect type.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use log::info;
+    /// use screeps::{prelude::*, LocalRoomPosition};
+    ///
+    /// let creep = screeps::game::creeps::get("mycreepname").unwrap();
+    /// let mem = creep.memory();
+    /// let pos = mem.get::<LocalRoomPosition>("saved_pos").unwrap();
+    /// let pos = match pos {
+    ///     Some(pos) => {
+    ///         info!("found position: {}", pos);
+    ///         pos
+    ///     }
+    ///     None => {
+    ///         info!("no position. saving new one!");
+    ///         let pos = creep.pos().local();
+    ///         mem.set("saved_pos", pos);
+    ///         pos
+    ///     }
+    /// };
+    /// info!("final position: {}", pos);
+    /// creep.move_to(&pos);
+    /// ```
     pub fn get<T>(&self, key: &str) -> Result<Option<T>, ConversionError>
     where
         T: TryFrom<Value, Error = ConversionError>,

--- a/screeps-game-api/src/positions.rs
+++ b/screeps-game-api/src/positions.rs
@@ -315,6 +315,45 @@ mod serde {
     js_serializable!(LocalRoomName);
 }
 
+/// This is a room position located in Rust memory.
+///
+/// It's "local" in the sense that while `RoomPosition` always references a room
+/// position allocated by and managed by the JavaScript VM, this is a
+/// self-contained plain-data struct in Rust memory.
+///
+/// # Using LocalRoomPosition
+///
+/// A `LocalRoomPosition` can be retrieved at any point by using
+/// [`RoomPosition::local`]. It can then be copied around freely, and have its
+/// values modified.
+///
+/// `&LocalRoomPosition` can be passed into any game method taking an object,
+/// and will be automatically uploaded to JavaScript as a `RoomPosition`.
+///
+/// If you need to manually create a `RoomPosition` from a `LocalRoomPosition`,
+/// use [`LocalRoomPosition::remote`].
+///
+/// # Serialization
+///
+/// `LocalRoomPosition` implements both `serde::Serialize` and
+/// `serde::Deserialize`.
+///
+/// When serializing, it will use the obvious format of `{roomName: String, x:
+/// u32, y: u32}` in "human readable" formats like JSON, and a less obvious
+/// format `{room_x: u32, room_y: u32, x: u32, y: u32}` in "non-human readable"
+/// formats like [`bincode`].
+///
+/// You can also pass `LocalRoomPosition` into JavaScript using the `js!{}`
+/// macro provided by `stdweb`, or helper methods using the same code like
+/// [`MemoryReference::set`][crate::memory::MemoryReference::set].  It will be
+/// serialized the same as in JSON, as an object with `roomName`, `x` and `y`
+/// properties.
+///
+/// *Note:* serializing using `js!{}` or `MemoryReference::set` will _not_
+/// create a `RoomPosition`, only something with the same properties. Use
+/// `.remote()` if you need a `RoomPosition`.
+///
+/// [`bincode`]: https://github.com/servo/bincode
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct LocalRoomPosition {
     pub room_name: LocalRoomName,

--- a/screeps-game-api/src/positions.rs
+++ b/screeps-game-api/src/positions.rs
@@ -323,7 +323,8 @@ pub struct LocalRoomPosition {
 }
 
 impl fmt::Display for LocalRoomPosition {
-    /// Formats this into a nice looking string mimicking `RoomPosition`'s `toString`.
+    /// Formats this into a nice looking string mimicking `RoomPosition`'s
+    /// `toString`.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[room {} pos {},{}]", self.room_name, self.x, self.y)
     }

--- a/screeps-game-api/src/positions.rs
+++ b/screeps-game-api/src/positions.rs
@@ -361,6 +361,17 @@ mod stdweb {
             Ok(LocalRoomPosition { x, y, room_name })
         }
     }
+
+    // We don't use `js_deserializable!` since it would generate pretty much exactly
+    // the code above, but with slightly extra cost since our `serde::Deserialize`
+    // implementation has extra code to be backwards compatible with a different
+    // format.
+    //
+    // On the other hand, we do want `js_serializable!()` since it does more than
+    // just implement `TryFrom<LocalRoomPosition> for Value` - it also gives us
+    // `JsSerializable` and other impls.
+
+    js_serializable!(LocalRoomPosition);
 }
 
 mod room_pos_serde {


### PR DESCRIPTION
This changes `LocalRoomPosition`'s serialized format from a kind-of-weird custom one to be that same kind-of-weird custom one when serializing to a binary format like bincode, but to be the regular format when serializing or deserializing from a "human readable" format like JSON or stdweb::Value.

In addition, this adds a call to `js_serializable!()` so `LocalRoomPosition`s can be passed directly into JavaScript code, and are serialized as objects.

Since serialization is now possible, this adds an example using `LocalRoomPosition` in the `MemoryReference::set` docs. This example should resolve #159.

One thing to note: the object produced by serializing `LocalRoomPosition` via `js!{}` won't be a `RoomPosition`, just an object with the same properties. This is documented in the `LocalRoomPosition` doc-comment.