### PR TITLE
Fix a few getters missing str_to_num conversions

### DIFF
--- a/screeps-game-api/src/objects/impls/construction_site.rs
+++ b/screeps-game-api/src/objects/impls/construction_site.rs
@@ -10,7 +10,6 @@ simple_accessors! {
     (my -> my -> bool),
     (progress -> progress -> u32),
     (progress_total -> progressTotal -> u32),
-    (structure_type -> structureType -> StructureType),
 }
 
 impl ConstructionSite {
@@ -29,5 +28,9 @@ impl ConstructionSite {
 
     pub fn remove(&self) -> ReturnCode {
         js_unwrap!(@{self.as_ref()}.remove())
+    }
+
+    pub fn structure_type(&self) -> StructureType {
+        js_unwrap!(__structure_type_str_to_num(@{self.as_ref()}.structureType))
     }
 }

--- a/screeps-game-api/src/objects/impls/mineral.rs
+++ b/screeps-game-api/src/objects/impls/mineral.rs
@@ -8,7 +8,12 @@ simple_accessors! {
     Mineral;
     (density -> density -> u32),
     (mineral_amount -> mineralAmount -> Density),
-    (mineral_type -> mineralType -> ResourceType),
     // id from HasId trait
     (ticks_to_regeneration -> ticksToRegeneration -> u32),
+}
+
+impl Mineral {
+    pub fn mineral_type(&self) -> ResourceType {
+        js_unwrap!(__resource_type_str_to_num(@{self.as_ref()}.mineralType))
+    }
 }

--- a/screeps-game-api/src/objects/impls/structure_lab.rs
+++ b/screeps-game-api/src/objects/impls/structure_lab.rs
@@ -13,9 +13,7 @@ simple_accessors! {
 
 impl StructureLab {
     pub fn mineral_type(&self) -> ResourceType {
-        js_unwrap! {
-            return __resource_type_str_to_num(@{self.as_ref()}.mineralType);
-        }
+        js_unwrap!(__resource_type_str_to_num(@{self.as_ref()}.mineralType))
     }
 
     pub fn boost_creep(&self, creep: &Creep, body_part_count: Option<u32>) -> ReturnCode {


### PR DESCRIPTION
Found these when looking over all usages of the types which newly implement `Serialize_repr` / `Deserialize_repr` in #164. These should be broken both before and after that PR, so filing it separately.