### PR TITLE
Utilize 'Look' constant when reading look* results

### DIFF
--- a/screeps-game-api/javascript/utils.js
+++ b/screeps-game-api/javascript/utils.js
@@ -44,6 +44,24 @@ function __look_num_to_str(num) {
     }
 }
 
+function __look_str_to_num(num) {
+    switch (num) {
+        case LOOK_CREEPS: return 0;
+        case LOOK_ENERGY: return 1;
+        case LOOK_RESOURCES: return 2;
+        case LOOK_SOURCES: return 3;
+        case LOOK_MINERALS: return 4;
+        case LOOK_STRUCTURES: return 5;
+        case LOOK_FLAGS: return 6;
+        case LOOK_CONSTRUCTION_SITES: return 7;
+        case LOOK_NUKES: return 8;
+        case LOOK_TERRAIN: return 9;
+        case LOOK_TOMBSTONES: return 10;
+        case LOOK_POWER_CREEPS: return 11;
+        default: throw new Error("unknown look constant " + num);
+    }
+}
+
 function __structure_type_num_to_str(num) {
     switch (num) {
         case 0: return STRUCTURE_SPAWN;

--- a/screeps-game-api/src/objects/impls/room.rs
+++ b/screeps-game-api/src/objects/impls/room.rs
@@ -13,7 +13,7 @@ use stdweb::{Reference, Value};
 
 use crate::{
     constants::{
-        Color, Direction, ExitDirection, FindConstant, LookConstant, PowerType, ResourceType,
+        Color, Direction, ExitDirection, FindConstant, Look, LookConstant, PowerType, ResourceType,
         ReturnCode, StructureType, Terrain,
     },
     macros::*,
@@ -752,29 +752,26 @@ impl TryFrom<Value> for LookResult {
     type Error = ConversionError;
 
     fn try_from(v: Value) -> Result<LookResult, Self::Error> {
-        let look_type: String = js!(return @{&v}.type;).try_into()?;
+        let look_type = js! (
+            return __look_str_to_num(@{&v}.type);
+        )
+        .try_into()?;
 
-        let lr = match look_type.as_ref() {
-            "creep" => LookResult::Creep(js_unwrap_ref!(@{v}.creep)),
-            "energy" => LookResult::Energy(js_unwrap_ref!(@{v}.energy)),
-            "resource" => LookResult::Resource(js_unwrap_ref!(@{v}.resource)),
-            "source" => LookResult::Source(js_unwrap_ref!(@{v}.source)),
-            "mineral" => LookResult::Mineral(js_unwrap_ref!(@{v}.mineral)),
-            "structure" => LookResult::Structure(js_unwrap_ref!(@{v}.structure)),
-            "flag" => LookResult::Flag(js_unwrap_ref!(@{v}.flag)),
-            "constructionSite" => {
+        let lr = match look_type {
+            Look::Creeps => LookResult::Creep(js_unwrap_ref!(@{v}.creep)),
+            Look::Energy => LookResult::Energy(js_unwrap_ref!(@{v}.energy)),
+            Look::Resources => LookResult::Resource(js_unwrap_ref!(@{v}.resource)),
+            Look::Sources => LookResult::Source(js_unwrap_ref!(@{v}.source)),
+            Look::Minerals => LookResult::Mineral(js_unwrap_ref!(@{v}.mineral)),
+            Look::Structures => LookResult::Structure(js_unwrap_ref!(@{v}.structure)),
+            Look::Flags => LookResult::Flag(js_unwrap_ref!(@{v}.flag)),
+            Look::ConstructionSites => {
                 LookResult::ConstructionSite(js_unwrap_ref!(@{v}.constructionSite))
             }
-            "nuke" => LookResult::Nuke(js_unwrap_ref!(@{v}.nuke)),
-            "terrain" => LookResult::Terrain(js_unwrap!(__terrain_str_to_num(@{v}.terrain))),
-            "tombstone" => LookResult::Tombstone(js_unwrap_ref!(@{v}.tombstone)),
-            "powerCreep" => LookResult::PowerCreep(js_unwrap_ref!(@{v}.powerCreep)),
-            _ => {
-                return Err(ConversionError::Custom(format!(
-                    "Look result type unknown: {:?}",
-                    &look_type
-                )));
-            }
+            Look::Nukes => LookResult::Nuke(js_unwrap_ref!(@{v}.nuke)),
+            Look::Terrain => LookResult::Terrain(js_unwrap!(__terrain_str_to_num(@{v}.terrain))),
+            Look::Tombstones => LookResult::Tombstone(js_unwrap_ref!(@{v}.tombstone)),
+            Look::PowerCreeps => LookResult::PowerCreep(js_unwrap_ref!(@{v}.powerCreep)),
         };
         Ok(lr)
     }


### PR DESCRIPTION
Slightly consolidates places where we match on constant strings! Should be very slightly more efficient too, sending an integer over.