### PR TITLE
Remove workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ target
 
 # Build files #
 ###############
-/Cargo.lock
+*/Cargo.lock
 
 # Packages #
 ############

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,0 @@
-[workspace]
-members = [
-    "screeps-game-api",
-    "cargo-screeps",
-]


### PR DESCRIPTION
This removes the shared workspace between `screeps-game-api` and `cargo-screeps`.

Advantages are allowing each project individually to be part of a bigger custom workspace (in the presence of https://github.com/rust-lang/cargo/issues/5042) and separating `Cargo.lock` files when developing. Disadvantage is not having the whole project under one Cargo project by default?

After thinking about it, it's probably not too common to develop `screeps-game-api` alongside `cargo-screeps`. While they interact, they aren't super intertwined.