### PR TITLE
Depend directly on cargo-web

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,25 +7,6 @@ os:
 - osx
 install:
 - rustup target add wasm32-unknown-unknown
-- | # download cargo web
-    cargo_web_release=$(curl -L -s -H 'Accept: application/json' \
-        https://github.com/koute/cargo-web/releases/latest)
-    cargo_web_version=$(echo $cargo_web_release \
-        | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
-    if [ "$(uname -s)" == "Darwin" ]; then
-      cargo_web_host_triple="x86_64-apple-darwin"
-    else
-      cargo_web_host_triple="x86_64-unknown-linux-gnu"
-    fi
-    cargo_web_url_prefix="https://github.com/koute/cargo-web/releases/download"
-    cargo_web_url="$cargo_web_url_prefix/$cargo_web_version/cargo-web-$cargo_web_host_triple.gz"
-
-    echo "Downloading cargo-web from: $cargo_web_url"
-    curl -L "$cargo_web_url" | gzip -d > cargo-web
-    chmod +x cargo-web
-
-    mkdir -p ~/.cargo/bin
-    mv cargo-web ~/.cargo/bin
 script:
 - (cd cargo-screeps && cargo build --verbose)
 - (cd cargo-screeps && cargo test --verbose)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ cd screeps-starter-rust
 # cli dependencies:
 
 cargo install cargo-screeps
-cargo install cargo-web
 
 # configure for uploading:
 

--- a/cargo-screeps/Cargo.toml
+++ b/cargo-screeps/Cargo.toml
@@ -21,6 +21,8 @@ description = "Build tool for deploying Rust WASM code to Screeps game servers"
 [dependencies]
 base64 = "0.10"
 clap = "2"
+# We rely on the output format of cargo-web, which is not a publicly guaranteed property.
+cargo-web = "=0.6.26"
 failure = "0.1"
 fern = "0.5"
 log = "0.4"
@@ -30,4 +32,5 @@ reqwest = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_ignored = "0.0.4"
 serde_json = "1"
+structopt = "0.2"
 toml = "0.5"

--- a/cargo-screeps/README.md
+++ b/cargo-screeps/README.md
@@ -5,11 +5,10 @@ cargo-screeps
 
 Build tool for deploying Rust WASM code to Screeps game servers.
 
-Best used with [`screeps-game-api`].
+`cargo-screeps` is a direct wrapper of [`cargo-web`], and depends on it internally. It adds the
+ability to trim output files for use in `screeps`, and upload to screeps server.
 
-This implements type-safe WASM bindings to the Screeps in-game API.
-
-This is not fully tested, but feel free to use! Issues are welcome.
+Intended to be used with [`screeps-game-api`], type-safe WASM bindings to the Screeps in-game API.
 
 ---
 
@@ -19,7 +18,7 @@ This is not fully tested, but feel free to use! Issues are welcome.
 
 Configured in `[build]` config section. No required settings.
 
-1. run https://github.com/koute/cargo-web to actually build rust source
+1. run `cargo-web build --release` to build the rust source
 2. strip off header / surrounding function `cargo-web` generates for a generic JS file to load from
    web or from local filesystem
 3. append initialization call using bytes from `require('<compiled module name>')`
@@ -55,7 +54,7 @@ Requires `default_deploy_mode` configuration setting.
 Does not require configuration.
 
 1. perform type checking / lifetime checking without compiling code
-  - runs `cargo web --check --target=wasm32-unknown-unknown` which is fairly similar to
+  - runs `cargo web check --target=wasm32-unknown-unknown` which is fairly similar to
     `cargo check`.
 
 # Configuration Options
@@ -129,19 +128,16 @@ See [docs/initialization-header.md] for more information on this.
 
 # Updating `cargo screeps`
 
-As it parses the unstable output of `cargo-web`, `cargo-screeps` is highly dependent on `cargo-web`
-version. It is recommended to upgrade both together.
+`cargo-screeps` no longer requires installing `cargo-web`, so if you've previously installed both,
+you can now freely remove the latter. It won't hurt to have it installed, but `cargo-screeps` will
+not use it.
 
-Installing a version of `cargo-web` newer than what `cargo-screeps` supports will cause it to
-output an error on build. If this happens, please create an issue on this repository and we can
-update `cargo-screeps`. Updating it is simple, but it needs to be done every time `cargo-web`
-changes the output format, and we might not realize that has happened.
+To update `cargo-screeps`, simply repeat the install process with the `--force` (`-f`) flag.
 
 After updating, you'll want to do a full `cargo clean` to remove any old artifacts which were built
 using the older version of `cargo-web`.
 
 ```sh
-cargo install -f cargo-web
 cargo install -f cargo-screeps
 cargo clean
 cargo screeps build
@@ -150,5 +146,6 @@ cargo screeps build
 [cratesio-badge]: http://meritbadge.herokuapp.com/cargo-screeps
 [crate]: https://crates.io/crates/cargo-screeps/
 [`screeps-game-api`]: https://github.com/daboross/screeps-in-rust-via-wasm/
+[`cargo-web`]: https://github.com/koute/cargo-web
 [screepsmod-auth]: https://www.npmjs.com/package/screepsmod-auth
 

--- a/cargo-screeps/README.md
+++ b/cargo-screeps/README.md
@@ -18,44 +18,42 @@ Intended to be used with [`screeps-game-api`], type-safe WASM bindings to the Sc
 
 Configured in `[build]` config section. No required settings.
 
-1. run `cargo-web build --release` to build the rust source
-2. strip off header / surrounding function `cargo-web` generates for a generic JS file to load from
-   web or from local filesystem
-3. append initialization call using bytes from `require('<compiled module name>')`
-4. put processed JS into `target/main.js` copy compiled WASM into `target/compiled.wasm`
+1. runs `cargo-web build --release` to build the rust source
+2. strips off header `cargo-web` generates for loading WASM file from a URL or the local filesystem
+3. appends initialization call using bytes from `require('<compiled module name>')`
+4. puts processed JS into `target/main.js` copy compiled WASM into `target/compiled.wasm`
 
 ### `upload`:
 
 Requires `[upload]` config section with at minimum username, password and branch.
 
-1. run build
-2. read `target/*.js` and `target/*.wasm`, keeping track of filenames
-3. read `screeps.toml` for upload options
-4. upload all read files to server, using filenames as the filenames on the server
+1. runs build
+2. reads `target/*.js` and `target/*.wasm`, keeping track of filenames
+3. reads `screeps.toml` for upload options
+4. uploads all read files to server, using filenames as the filenames on the server
 
 ### `copy`:
 
 Requires `[copy]` config section with at minimum destination and branch.
 
-1. run build
-2. copy compiled main file and WASM file (default `main.js` and `compiled.wasm`) from `target/` to
+1. runs build
+2. copies compiled main file and WASM file (default `main.js` and `compiled.wasm`) from `target/` to
    `<destination directory>/<branch name>/`
-3. if pruning is enabled, delete all other files in `<destination directory>/<branch name>/`
+3. if pruning is enabled, deletes all other files in `<destination directory>/<branch name>/`
 
 ### `deploy`:
 
 Requires `default_deploy_mode` configuration setting.
 
-1. run build
-2. run `upload` or `copy` depending on the `default_deploy_mode` configuration option
+1. runs build
+2. runs `upload` or `copy` depending on the `default_deploy_mode` configuration option
 
 ### `check`:
 
 Does not require configuration.
 
-1. perform type checking / lifetime checking without compiling code
-  - runs `cargo web check --target=wasm32-unknown-unknown` which is fairly similar to
-    `cargo check`.
+1. performs type checking and lifetime checking without compiling code
+  - runs `cargo web check` (see `cargo check` for non-WASM codebases)
 
 # Configuration Options
 
@@ -128,14 +126,10 @@ See [docs/initialization-header.md] for more information on this.
 
 # Updating `cargo screeps`
 
-`cargo-screeps` no longer requires installing `cargo-web`, so if you've previously installed both,
-you can now freely remove the latter. It won't hurt to have it installed, but `cargo-screeps` will
-not use it.
-
 To update `cargo-screeps`, simply repeat the install process with the `--force` (`-f`) flag.
 
 After updating, you'll want to do a full `cargo clean` to remove any old artifacts which were built
-using the older version of `cargo-web`.
+using the older version of `cargo-screeps`.
 
 ```sh
 cargo install -f cargo-screeps

--- a/cargo-screeps/src/build.rs
+++ b/cargo-screeps/src/build.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, ffi::OsStr, fs, io::Write, path::Path};
+use std::{borrow::Cow, env, ffi::OsStr, fs, io::Write, path::Path};
 
 use cargo_web::{BuildOpts, CargoWebOpts, CheckOpts};
 use failure::{bail, ensure, format_err};
@@ -9,6 +9,10 @@ use crate::config::{BuildConfiguration, Configuration};
 
 pub fn check(root: &Path) -> Result<(), failure::Error> {
     debug!("running check");
+
+    debug!("changing directory to {}", root.display());
+
+    env::set_current_dir(&root)?;
 
     debug!("running cargo-web check --target=wasm32-unknown-unknown");
 
@@ -26,6 +30,10 @@ pub fn check(root: &Path) -> Result<(), failure::Error> {
 
 pub fn build(root: &Path, config: &Configuration) -> Result<(), failure::Error> {
     debug!("building");
+
+    debug!("changing directory to {}", root.display());
+
+    env::set_current_dir(&root)?;
 
     debug!("running cargo-web build --target=wasm32-unknown-unknown --release");
 

--- a/cargo-screeps/src/upload.rs
+++ b/cargo-screeps/src/upload.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fs, io::Read, path::Path};
 
-use failure::{ensure, format_err, bail};
+use failure::{bail, ensure, format_err};
 use log::*;
 use serde::Serialize;
 


### PR DESCRIPTION
This removes the process indirection when calling into `cargo-web` from `cargo-screeps`, and also removes the need to install both side-by-side.

Now `cargo-screeps` vendors/packages/compiles with `cargo-web` internally, and will use that internal code to compile the project.

Fixes #6.