### PR TITLE
Bring back SearchResults::opaque_path()

### DIFF
--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -127,6 +127,10 @@ impl SearchResults {
             .map(|p: RoomPosition| p.into())
             .collect()
     }
+
+    pub fn opaque_path(&self) -> Array {
+       self.path_internal()
+    }
 }
 
 pub trait RoomCostResult: Into<JsValue> {}


### PR DESCRIPTION
This was part of the 0.9.0 API and it is required to pass that path to functions like `creep.move_by_path()`.