### PR TITLE
Creep::ticks_to_live returns Option

### DIFF
--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -101,7 +101,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.ticksToLive)
     #[wasm_bindgen(method, getter = ticksToLive)]
-    pub fn ticks_to_live(this: &Creep) -> u32;
+    pub fn ticks_to_live(this: &Creep) -> Option<u32>;
 
     /// Attack a target in melee range using a creep's attack parts.
     ///
@@ -418,7 +418,7 @@ impl SharedCreepProperties for Creep {
         Self::saying(self)
     }
 
-    fn ticks_to_live(&self) -> u32 {
+    fn ticks_to_live(&self) -> Option<u32> {
         Self::ticks_to_live(self)
     }
 

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -136,7 +136,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.ticksToLive)
     #[wasm_bindgen(method, getter = ticksToLive)]
-    pub fn ticks_to_live(this: &PowerCreep) -> u32;
+    pub fn ticks_to_live(this: &PowerCreep) -> Option<u32>;
 
     /// Cancel an a successfully called power creep function from earlier in the
     /// tick, with a [`JsString`] that must contain the JS version of the
@@ -331,7 +331,7 @@ impl SharedCreepProperties for PowerCreep {
         Self::saying(self)
     }
 
-    fn ticks_to_live(&self) -> u32 {
+    fn ticks_to_live(&self) -> Option<u32> {
         Self::ticks_to_live(self)
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -193,7 +193,7 @@ pub trait SharedCreepProperties {
     fn saying(&self) -> Option<JsString>;
 
     /// The number of ticks the creep has left to live.
-    fn ticks_to_live(&self) -> u32;
+    fn ticks_to_live(&self) -> Option<u32>;
 
     /// Cancel an a successfully called creep function from earlier in the tick,
     /// with a [`JsString`] that must contain the JS version of the function


### PR DESCRIPTION
because the game returns undefined for creeps that are currently spawning