### PR TITLE
Overhaul of RoomXY, nightly feature

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,8 +11,8 @@ jobs:
         with:
           components: clippy, rustfmt
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-features -- -D warnings
-      - run: cargo test --all-features
+      - run: cargo clippy --features mmo,seasonal-season-1,seasonal-season-2,seasonal-season-5,sim,unsafe-return-conversion -- -D warnings
+      - run: cargo test --features mmo,seasonal-season-1,seasonal-season-2,seasonal-season-5,sim,unsafe-return-conversion
   nightly:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,5 @@ sim = []
 # Enable unsafe conversions of return codes with undefined behavior when values
 # aren't in the expected range
 unsafe-return-conversion = []
+
+nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,10 @@
 // to build locally with doc_cfg enabled, run:
 // `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features`
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(feature = "nightly", feature(step_trait))]
+#![cfg_attr(
+    feature = "nightly",
+    feature(step_trait, trusted_step, min_specialization)
+)]
 // warn when functions can safely be given the const keyword, see
 // https://rust-lang.github.io/rust-clippy/master/index.html#/missing_const_for_fn
 // unfortunately this warns for bindgen-attached functions so we can't leave it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@
 // to build locally with doc_cfg enabled, run:
 // `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features`
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(feature = "nightly", feature(step_trait))]
 // warn when functions can safely be given the const keyword, see
 // https://rust-lang.github.io/rust-clippy/master/index.html#/missing_const_for_fn
 // unfortunately this warns for bindgen-attached functions so we can't leave it

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -340,6 +340,18 @@ impl Sub for RoomCoordinate {
     }
 }
 
+impl std::cmp::PartialOrd<u8> for RoomCoordinate {
+    fn partial_cmp(&self, other: &u8) -> Option<std::cmp::Ordering> {
+        Some(self.0.cmp(other))
+    }
+}
+
+impl std::cmp::PartialEq<u8> for RoomCoordinate {
+    fn eq(&self, other: &u8) -> bool {
+        self.0 == *other
+    }
+}
+
 const ROOM_SIZE_I8: i8 = {
     // If this fails, we need to rework the arithmetic code
     debug_assert!(2 * ROOM_SIZE <= i8::MAX as u8);
@@ -439,7 +451,7 @@ impl RoomOffset {
     pub fn saturating_add(self, rhs: Self) -> Self {
         self.assume_bounds_constraint();
         rhs.assume_bounds_constraint();
-        Self::new((self.0 + rhs.0).clamp(-ROOM_SIZE_I8 + 1, ROOM_SIZE_I8 - 1)).unwrap_throw()
+        Self::saturating_new(self.0 + rhs.0)
     }
 
     /// Add two offsets together, wrapping around at the ends of the valid
@@ -528,6 +540,12 @@ impl RoomOffset {
     }
 }
 
+impl fmt::Display for RoomOffset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl From<RoomOffset> for i8 {
     fn from(offset: RoomOffset) -> i8 {
         offset.0
@@ -563,6 +581,18 @@ impl Neg for RoomOffset {
     fn neg(self) -> Self::Output {
         self.assume_bounds_constraint();
         Self::new(-self.0).unwrap_throw()
+    }
+}
+
+impl std::cmp::PartialOrd<i8> for RoomOffset {
+    fn partial_cmp(&self, other: &i8) -> Option<std::cmp::Ordering> {
+        Some(self.0.cmp(other))
+    }
+}
+
+impl std::cmp::PartialEq<i8> for RoomOffset {
+    fn eq(&self, other: &i8) -> bool {
+        self.0 == *other
     }
 }
 

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -634,7 +634,7 @@ impl std::iter::Step for RoomCoordinate {
 
     fn forward(start: Self, count: usize) -> Self {
         if cfg!(debug_assertions) {
-            start.forward_checked(count).unwrap_throw()
+            RoomCoordinate::forward_checked(start, count).unwrap_throw()
         } else {
             start.saturating_add(count.min(ROOM_USIZE) as i8)
         }
@@ -642,7 +642,7 @@ impl std::iter::Step for RoomCoordinate {
 
     fn backward(start: Self, count: usize) -> Self {
         if cfg!(debug_assertions) {
-            start.backward_checked(count).unwrap_throw()
+            RoomCoordinate::backward_checked(start, count).unwrap_throw()
         } else {
             start.saturating_add(-(count.min(ROOM_USIZE) as i8))
         }
@@ -687,7 +687,7 @@ impl std::iter::Step for RoomOffset {
 
     fn forward(start: Self, count: usize) -> Self {
         if cfg!(debug_assertions) {
-            start.forward_checked(count).unwrap_throw()
+            RoomOffset::forward_checked(start, count).unwrap_throw()
         } else {
             start.assume_bounds_constraint();
             Self::saturating_new(start.0.saturating_add(count.min(2 * ROOM_USIZE) as i8))
@@ -696,7 +696,7 @@ impl std::iter::Step for RoomOffset {
 
     fn backward(start: Self, count: usize) -> Self {
         if cfg!(debug_assertions) {
-            start.backward_checked(count).unwrap_throw()
+            RoomOffset::backward_checked(start, count).unwrap_throw()
         } else {
             start.assume_bounds_constraint();
             Self::saturating_new(start.0.saturating_sub(count.min(2 * ROOM_USIZE) as i8))

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -562,6 +562,53 @@ impl Neg for RoomOffset {
     }
 }
 
+#[cfg(feature = "nightly")]
+impl std::iter::Step for RoomCoordinate {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        end.0.checked_sub(start.0).map(|x| x as usize)
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        if count < ROOM_USIZE {
+            start.checked_add(count as i8)
+        } else {
+            None
+        }
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        if count < ROOM_USIZE {
+            start.checked_add(-(count as i8))
+        } else {
+            None
+        }
+    }
+
+    fn forward(start: Self, count: usize) -> Self {
+        if cfg!(debug_assertions) {
+            self.forward_checked(count).unwrap_throw()
+        } else {
+            self.saturating_add(count.min(ROOM_USIZE) as i8)
+        }
+    }
+
+    fn backward(start: Self, count: usize) -> Self {
+        if cfg!(debug_assertions) {
+            self.backward_checked(count).unwrap_throw()
+        } else {
+            self.saturating_add(-(count.min(ROOM_USIZE) as i8))
+        }
+    }
+
+    unsafe fn forward_unchecked(start: Self, count: usize) -> Self {
+        start.unchecked_add(count as i8)
+    }
+
+    unsafe fn backward_unchecked(start: Self, count: usize) -> Self {
+        start.unchecked_add(-(count as i8))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -370,7 +370,10 @@ pub struct RoomOffset(i8);
 
 impl RoomOffset {
     pub const MAX: Self = Self(ROOM_SIZE_I8 - 1);
-    pub const MIN: Self = Self(1 - ROOM_SIZE_I8);
+    pub const MIN: Self = Self(-(ROOM_SIZE_I8 - 1));
+    pub const PLUS_ONE: Self = Self(1);
+    pub const MINUS_ONE: Self = Self(-1);
+    pub const ZERO: Self = Self(0);
 
     /// Create a `RoomOffset` from an `i8`, returning an error if it's not
     /// within the valid range.
@@ -420,12 +423,12 @@ impl RoomOffset {
     /// ```
     /// use screeps::local::RoomOffset;
     ///
-    /// let zero = RoomOffset::new(0).unwrap();
-    /// let one = RoomOffset::new(1).unwrap();
-    ///
-    /// assert_eq!(RoomOffset::MIN.checked_add(RoomOffset::MAX), Some(zero));
-    /// assert_eq!(RoomOffset::MAX.checked_add(one), None);
-    /// assert_eq!(RoomOffset::MIN.checked_add(-one), None);
+    /// assert_eq!(
+    ///     RoomOffset::MIN.checked_add(RoomOffset::MAX),
+    ///     Some(RoomOffset::ZERO)
+    /// );
+    /// assert_eq!(RoomOffset::MAX.checked_add(RoomOffset::PLUS_ONE), None);
+    /// assert_eq!(RoomOffset::MIN.checked_add(RoomOffset::MINUS_ONE), None);
     /// ```
     pub fn checked_add(self, rhs: Self) -> Option<Self> {
         self.assume_bounds_constraint();
@@ -441,12 +444,18 @@ impl RoomOffset {
     /// ```
     /// use screeps::local::RoomOffset;
     ///
-    /// let zero = RoomOffset::new(0).unwrap();
-    /// let one = RoomOffset::new(1).unwrap();
-    ///
-    /// assert_eq!(RoomOffset::MIN.saturating_add(RoomOffset::MAX), zero);
-    /// assert_eq!(RoomOffset::MAX.saturating_add(one), RoomOffset::MAX);
-    /// assert_eq!(RoomOffset::MIN.saturating_add(-one), RoomOffset::MIN);
+    /// assert_eq!(
+    ///     RoomOffset::MIN.saturating_add(RoomOffset::MAX),
+    ///     RoomOffset::ZERO
+    /// );
+    /// assert_eq!(
+    ///     RoomOffset::MAX.saturating_add(RoomOffset::PLUS_ONE),
+    ///     RoomOffset::MAX
+    /// );
+    /// assert_eq!(
+    ///     RoomOffset::MIN.saturating_add(RoomOffset::MINUS_ONE),
+    ///     RoomOffset::MIN
+    /// );
     /// ```
     pub fn saturating_add(self, rhs: Self) -> Self {
         self.assume_bounds_constraint();
@@ -462,20 +471,17 @@ impl RoomOffset {
     /// ```
     /// use screeps::local::RoomOffset;
     ///
-    /// let zero = RoomOffset::new(0).unwrap();
-    /// let one = RoomOffset::new(1).unwrap();
-    ///
     /// assert_eq!(
-    ///     RoomOffset::MAX.overflowing_add(one),
+    ///     RoomOffset::MAX.overflowing_add(RoomOffset::PLUS_ONE),
     ///     (RoomOffset::MIN, true)
     /// );
     /// assert_eq!(
-    ///     RoomOffset::MIN.overflowing_add(-one),
+    ///     RoomOffset::MIN.overflowing_add(RoomOffset::MINUS_ONE),
     ///     (RoomOffset::MAX, true)
     /// );
     /// assert_eq!(
     ///     RoomOffset::MIN.overflowing_add(RoomOffset::MAX),
-    ///     (zero, false)
+    ///     (RoomOffset::ZERO, false)
     /// );
     /// ```
     pub fn overflowing_add(self, rhs: Self) -> (Self, bool) {
@@ -500,12 +506,18 @@ impl RoomOffset {
     /// ```
     /// use screeps::local::RoomOffset;
     ///
-    /// let zero = RoomOffset::new(0).unwrap();
-    /// let one = RoomOffset::new(1).unwrap();
-    ///
-    /// assert_eq!(RoomOffset::MAX.wrapping_add(one), RoomOffset::MIN);
-    /// assert_eq!(RoomOffset::MIN.wrapping_add(-one), RoomOffset::MAX);
-    /// assert_eq!(RoomOffset::MIN.wrapping_add(RoomOffset::MAX), zero);
+    /// assert_eq!(
+    ///     RoomOffset::MAX.wrapping_add(RoomOffset::PLUS_ONE),
+    ///     RoomOffset::MIN
+    /// );
+    /// assert_eq!(
+    ///     RoomOffset::MIN.wrapping_add(RoomOffset::MINUS_ONE),
+    ///     RoomOffset::MAX
+    /// );
+    /// assert_eq!(
+    ///     RoomOffset::MIN.wrapping_add(RoomOffset::MAX),
+    ///     RoomOffset::ZERO
+    /// );
     /// ```
     pub fn wrapping_add(self, rhs: Self) -> Self {
         self.overflowing_add(rhs).0

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -634,17 +634,17 @@ impl std::iter::Step for RoomCoordinate {
 
     fn forward(start: Self, count: usize) -> Self {
         if cfg!(debug_assertions) {
-            self.forward_checked(count).unwrap_throw()
+            start.forward_checked(count).unwrap_throw()
         } else {
-            self.saturating_add(count.min(ROOM_USIZE) as i8)
+            start.saturating_add(count.min(ROOM_USIZE) as i8)
         }
     }
 
     fn backward(start: Self, count: usize) -> Self {
         if cfg!(debug_assertions) {
-            self.backward_checked(count).unwrap_throw()
+            start.backward_checked(count).unwrap_throw()
         } else {
-            self.saturating_add(-(count.min(ROOM_USIZE) as i8))
+            start.saturating_add(-(count.min(ROOM_USIZE) as i8))
         }
     }
 
@@ -673,21 +673,21 @@ impl std::iter::Step for RoomOffset {
         start.assume_bounds_constraint();
         i8::try_from(count)
             .ok()
-            .and_then(|count| self.0.checked_add(count))
-            .and_then(Self::new)
+            .and_then(|count| Self::new(count).ok())
+            .and_then(|offset| start.checked_add(offset))
     }
 
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         start.assume_bounds_constraint();
         i8::try_from(count)
             .ok()
-            .and_then(|count| start.0.checked_sub(count))
-            .and_then(Self::new)
+            .and_then(|count| Self::new(count).ok())
+            .and_then(|offset| start.checked_add(-offset))
     }
 
     fn forward(start: Self, count: usize) -> Self {
         if cfg!(debug_assertions) {
-            self.forward_checked(count).unwrap_throw()
+            start.forward_checked(count).unwrap_throw()
         } else {
             start.assume_bounds_constraint();
             Self::saturating_new(start.0.saturating_add(count.min(2 * ROOM_USIZE) as i8))
@@ -696,7 +696,7 @@ impl std::iter::Step for RoomOffset {
 
     fn backward(start: Self, count: usize) -> Self {
         if cfg!(debug_assertions) {
-            self.backward_checked(count).unwrap_throw()
+            start.backward_checked(count).unwrap_throw()
         } else {
             start.assume_bounds_constraint();
             Self::saturating_new(start.0.saturating_sub(count.min(2 * ROOM_USIZE) as i8))

--- a/src/local/room_xy/approximate_offsets.rs
+++ b/src/local/room_xy/approximate_offsets.rs
@@ -1,7 +1,7 @@
 //! Methods related to approximating in-room positions
 //! between other in-room positions.
 
-use super::RoomXY;
+use super::{RoomOffsetXY, RoomXY};
 
 impl RoomXY {
     /// Calculates an approximate midpoint between this point and the target.
@@ -50,14 +50,17 @@ impl RoomXY {
     /// );
     /// ```
     pub fn towards(self, target: RoomXY, distance_towards_target: i8) -> RoomXY {
-        let (offset_x, offset_y) = target - self;
-        let total_distance = offset_x.abs().max(offset_y.abs());
+        let RoomOffsetXY {
+            x: offset_x,
+            y: offset_y,
+        } = target - self;
+        let total_distance = offset_x.abs().max(offset_y.abs()) as i8;
         if distance_towards_target > total_distance {
             return target;
         }
 
-        let new_offset_x = (offset_x * distance_towards_target) / total_distance;
-        let new_offset_y = (offset_y * distance_towards_target) / total_distance;
+        let new_offset_x = (i8::from(offset_x) * distance_towards_target) / total_distance;
+        let new_offset_y = (i8::from(offset_y) * distance_towards_target) / total_distance;
 
         self + (new_offset_x, new_offset_y)
     }
@@ -178,7 +181,7 @@ impl RoomXY {
     /// );
     /// ```
     pub fn midpoint_between(self, target: RoomXY) -> RoomXY {
-        let (offset_x, offset_y) = self - target;
+        let (offset_x, offset_y) = <(i8, i8)>::from(self - target);
 
         let new_offset_x = offset_x / 2;
         let new_offset_y = offset_y / 2;

--- a/src/local/room_xy/extra_math.rs
+++ b/src/local/room_xy/extra_math.rs
@@ -3,7 +3,7 @@
 
 use std::ops::{Add, Sub};
 
-use super::RoomXY;
+use super::{RoomOffsetXY, RoomXY, XY};
 use crate::constants::Direction;
 
 impl RoomXY {
@@ -89,7 +89,7 @@ impl Add<Direction> for RoomXY {
     #[inline]
     #[track_caller]
     fn add(self, direction: Direction) -> Self {
-        self.checked_add_direction(direction).unwrap()
+        self.checked_add_offset(direction.into()).unwrap()
     }
 }
 
@@ -138,32 +138,7 @@ impl Sub<Direction> for RoomXY {
     /// ```
     #[inline]
     fn sub(self, direction: Direction) -> Self {
-        self.checked_add_direction(-direction).unwrap()
-    }
-}
-
-impl Sub<RoomXY> for RoomXY {
-    type Output = (i8, i8);
-
-    /// Subtracts the other position from this one, extracting the
-    /// difference as the output.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use screeps::RoomXY;
-    ///
-    /// let pos1 = RoomXY::checked_new(40, 40).unwrap();
-    /// let pos2 = RoomXY::checked_new(0, 20).unwrap();
-    /// assert_eq!(pos1 - pos2, (40, 20));
-    ///
-    /// let pos3 = RoomXY::checked_new(45, 45).unwrap();
-    /// assert_eq!(pos1 - pos3, (-5, -5));
-    /// ```
-    #[inline]
-    fn sub(self, other: RoomXY) -> (i8, i8) {
-        let dx = self.x.u8() as i8 - other.x.u8() as i8;
-        let dy = self.y.u8() as i8 - other.y.u8() as i8;
-        (dx, dy)
+        self.checked_add_offset(-RoomOffsetXY::from(direction))
+            .unwrap()
     }
 }

--- a/src/local/room_xy/extra_math.rs
+++ b/src/local/room_xy/extra_math.rs
@@ -3,7 +3,7 @@
 
 use std::ops::{Add, Sub};
 
-use super::{RoomOffsetXY, RoomXY, XY};
+use super::{RoomOffsetXY, RoomXY};
 use crate::constants::Direction;
 
 impl RoomXY {
@@ -39,7 +39,7 @@ impl RoomXY {
     #[inline]
     #[track_caller]
     pub fn offset(&mut self, x: i8, y: i8) {
-        *self = *self + (x, y);
+        *self = self.checked_add((x, y)).unwrap();
     }
 }
 

--- a/src/local/room_xy/game_math.rs
+++ b/src/local/room_xy/game_math.rs
@@ -1,9 +1,8 @@
 //! Utilities for doing math on [`RoomXY`]s which are present in the
 //! JavaScript API.
-
 use crate::constants::Direction;
 
-use super::RoomXY;
+use super::{RoomOffsetXY, RoomXY};
 
 impl RoomXY {
     /// Gets linear direction to the specified position.
@@ -14,7 +13,7 @@ impl RoomXY {
     /// if the target has a slightly different `x` coordinate.
     pub fn get_direction_to(self, target: RoomXY) -> Option<Direction> {
         // Logic copied from https://github.com/screeps/engine/blob/020ba168a1fde9a8072f9f1c329d5c0be8b440d7/src/utils.js#L73-L107
-        let (dx, dy) = target - self;
+        let RoomOffsetXY { x: dx, y: dy } = target - self;
         if dx.abs() > dy.abs() * 2 {
             if dx > 0 {
                 Some(Direction::Right)
@@ -59,8 +58,7 @@ impl RoomXY {
     #[doc(alias = "distance")]
     #[inline]
     pub fn get_range_to(self, target: RoomXY) -> u8 {
-        let (dx, dy) = self - target;
-        dx.unsigned_abs().max(dy.unsigned_abs())
+        (self - target).chebyshev_distance()
     }
 
     /// Checks whether this position is in the given range of another position.

--- a/src/local/room_xy/game_math.rs
+++ b/src/local/room_xy/game_math.rs
@@ -131,8 +131,7 @@ impl RoomXY {
     /// ```
     #[inline]
     pub fn is_near_to(self, target: RoomXY) -> bool {
-        (u8::from(self.x) as i32 - u8::from(target.x) as i32).abs() <= 1
-            && (u8::from(self.y) as i32 - u8::from(target.y) as i32).abs() <= 1
+        self.in_range_to(target, 1)
     }
 }
 


### PR DESCRIPTION
Overhauls RoomXY arithmetic, adds a RoomOffsetXY type to correspond with RoomOffsets. Also includes a nightly feature, which currently just enables the `Step` trait for RoomCoordinates/Offsets.