### PR TITLE
Prep 0.23.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Unreleased
 ==========
 
+0.23.3 (2026-04-04)
+===================
+
+### Misc:
+
+- Replace doc_auto_cfg build option to fix build of docs
+
 0.23.2 (2026-03-12)
 ===================
 


### PR DESCRIPTION
docs-only release due to the last release having deprecated docs options; a test has been added to prevent this in the future.