### PR TITLE
Add Score object and relevant constants for season 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 Unreleased
 ==========
 
+### Additions:
+
+- Add `Score` object used for season 10, enabled by new crate feature `seasonal-season-10`
+
 0.23.4 (2026-04-26)
 ===================
 
 ### Additions:
 
 - Add new error code `AccessDenied` to `ClaimControllerErrorCode`, `ReserveControllerErrorCode`,
-  and `UpgradeControllerErrorCode` enums.
+  and `UpgradeControllerErrorCode` enums
 - Add new functions for shard access - `game::shard::access`, `game::shard::access_time`, and
-  `game::shard::activate_access`, in addition to related error types.
+  `game::shard::activate_access`, in addition to related error types
 
 0.23.3 (2026-04-04)
 ===================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ seasonal-season-2 = []
 # Seasonal server, season 5 - enable thorium resource and reactor structure
 seasonal-season-5 = []
 
+# Seasonal server, season 10 - enable score object
+seasonal-season-10 = []
+
 # enable compatibility with the sim environment for positions
 sim = []
 

--- a/src/constants/seasonal.rs
+++ b/src/constants/seasonal.rs
@@ -348,3 +348,24 @@ pub mod season_5 {
         }
     }
 }
+
+// season 6/8 no new constants; season 7 constants integrated into season 1
+// since it was a tweaked re-run season 9 skipped to let season 10 coincide with
+// 10th anniversary of game's launch
+
+/// Constants for Screeps seasonal, season 10
+///
+/// These constants are relevant to the mechanics in seasonal, season 10.
+#[cfg(feature = "seasonal-season-10")]
+pub mod season_10 {
+    /// The percentage chance that a given room will have a [`Score`] spawned in
+    /// it every [`SCORE_SPAWN_INTERVAL_TICKS`] ticks.
+    ///
+    /// [`Score`]: crate::objects::Score
+    pub const SCORE_SPAWN_CHANCE: f32 = 0.01;
+    /// The number of ticks between chances to spawn a [`Score`] in rooms at
+    /// random.
+    ///
+    /// [`Score`]: crate::objects::Score
+    pub const SCORE_SPAWN_INTERVAL_TICKS: u32 = 250;
+}

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -62,6 +62,9 @@ mod room_objects {
 
     #[cfg(feature = "seasonal-season-5")]
     pub use super::impls::Reactor;
+
+    #[cfg(feature = "seasonal-season-10")]
+    pub use super::impls::Score;
 }
 
 /// Object wrappers allowing drawing of shapes in rooms or on the map in the

--- a/src/objects/impls.rs
+++ b/src/objects/impls.rs
@@ -55,6 +55,9 @@ mod symbol_decoder;
 #[cfg(feature = "seasonal-season-5")]
 mod reactor;
 
+#[cfg(feature = "seasonal-season-10")]
+mod score;
+
 pub use self::{
     construction_site::ConstructionSite,
     cost_matrix::CostMatrix,
@@ -119,3 +122,6 @@ pub use self::{symbol_container::SymbolContainer, symbol_decoder::SymbolDecoder}
 
 #[cfg(feature = "seasonal-season-5")]
 pub use self::reactor::Reactor;
+
+#[cfg(feature = "seasonal-season-10")]
+pub use self::score::Score;

--- a/src/objects/impls/score.rs
+++ b/src/objects/impls/score.rs
@@ -2,7 +2,7 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    objects::{RoomObject, Store},
+    objects::RoomObject,
     prelude::*,
 };
 

--- a/src/objects/impls/score.rs
+++ b/src/objects/impls/score.rs
@@ -1,0 +1,48 @@
+use js_sys::JsString;
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    objects::{RoomObject, Store},
+    prelude::*,
+};
+
+#[wasm_bindgen]
+extern "C" {
+    /// An reference to a javascript object representing a [`Score`], which
+    /// appears randomly around the map and adds to your score when stepped on
+    /// by one of your creeps.
+    ///
+    /// [Screeps documentation](https://docs-season.screeps.com/api/#Score)
+    #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone, Debug)]
+    pub type Score;
+
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &Score) -> JsString;
+
+    /// The amount of [`Score`] that this object is worth when collected by a
+    /// creep.
+    ///
+    /// [Screeps documentation](https://docs-season.screeps.com/api/#Score.score)
+    #[wasm_bindgen(method, getter)]
+    pub fn score(this: &Score) -> u32;
+
+    /// The number of ticks until the [`Score`] will decay, disappearing
+    /// completely.
+    ///
+    /// [Screeps documentation](https://docs-season.screeps.com/api/#Score.ticksToDecay)
+    #[wasm_bindgen(method, getter = ticksToDecay)]
+    pub fn ticks_to_decay(this: &Score) -> u32;
+}
+
+impl CanDecay for Score {
+    fn ticks_to_decay(&self) -> u32 {
+        Self::ticks_to_decay(self)
+    }
+}
+
+impl HasId for Score {
+    fn js_raw_id(&self) -> JsString {
+        Self::id_internal(self)
+    }
+}

--- a/src/objects/impls/score.rs
+++ b/src/objects/impls/score.rs
@@ -1,10 +1,7 @@
 use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
-use crate::{
-    objects::RoomObject,
-    prelude::*,
-};
+use crate::{objects::RoomObject, prelude::*};
 
 #[wasm_bindgen]
 extern "C" {


### PR DESCRIPTION
Based on the docs it looks like there's potentially more 'hidden' constants (score ranges and max decay time, etc) but until we can see those in-game and/or if the mod's published we can't verify, so starting with just what's documented directly.